### PR TITLE
Make delaySeconds optional as it's not supported by FIFO queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ def send(
 
 `SqsPublisherSettings` allows your to configure a number of things:
 
-- `delaySeconds`: see the [related page on AWS docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-timers.html) (default `0`)
+- `delaySeconds`: see the [related page on AWS docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-timers.html) (default `None`). This parameter should be `None` for a FIFO queue.
 - `messageDeduplicationId`: see the [related page on AWS docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html)
 - `messageGroupId`: see the [related page on AWS docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagegroupid-property.html)
 - `messageAttributes`: see the [related page on AWS docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-attributes.html)

--- a/src/main/scala/zio/sqs/SqsPublisher.scala
+++ b/src/main/scala/zio/sqs/SqsPublisher.scala
@@ -19,13 +19,13 @@ object SqsPublisher {
           .builder()
           .queueUrl(queueUrl)
           .messageBody(msg)
-          .delaySeconds(settings.delaySeconds)
           .messageAttributes(settings.messageAttributes.asJava)
         val b2 = if (settings.messageGroupId.nonEmpty) b1.messageGroupId(settings.messageGroupId) else b1
         val b3 =
           if (settings.messageDeduplicationId.nonEmpty) b2.messageDeduplicationId(settings.messageDeduplicationId)
           else b2
-        b3.build
+        val b4 = settings.delaySeconds.fold(b3)(b3.delaySeconds(_))
+        b4.build
       }.handle[Unit]((_, err) => {
         err match {
           case null => cb(IO.unit)

--- a/src/main/scala/zio/sqs/SqsPublisherSettings.scala
+++ b/src/main/scala/zio/sqs/SqsPublisherSettings.scala
@@ -3,7 +3,7 @@ package zio.sqs
 import software.amazon.awssdk.services.sqs.model.MessageAttributeValue
 
 case class SqsPublisherSettings(
-  delaySeconds: Int = 0,
+  delaySeconds: Option[Int] = None,
   messageAttributes: Map[String, MessageAttributeValue] = Map(),
   messageDeduplicationId: String = "",
   messageGroupId: String = ""


### PR DESCRIPTION
When the SQS queue is a FIFO queue, settings `delaySeconds` (even to 0) will cause an error.
This PR makes it optional.