### PR TITLE
Make visibilityTimeout and waitTimeSeconds settings optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ def apply(
 - `attributeNames`: see the [related page on AWS docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html)
 - `maxNumberOfMessages`: number of messages to query at once from SQS (default `1`)
 - `messageAttributeNames`: see the [related page on AWS docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html)
-- `visibilityTimeout`: see the [related page on AWS docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html) (default `30`)
-- `waitTimeSeconds`: see the [related page on AWS docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html) (default `20`),
+- `visibilityTimeout`: see the [related page on AWS docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html) (default `Some(30)`. If set to `None`, the queue's value will be used.)
+- `waitTimeSeconds`: see the [related page on AWS docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html) (default `Some(20)`. If set to `None`, the queue's value will be used.)
 
 **Example:**
 
@@ -143,7 +143,7 @@ import zio.sqs.{SqsStream, SqsStreamSettings}
 SqsStream(
   client,
   queueUrl,
-  SqsStreamSettings(stopWhenQueueEmpty = true, waitTimeSeconds = 3)
+  SqsStreamSettings(stopWhenQueueEmpty = true, waitTimeSeconds = Some(3))
 ).foreach(msg => UIO(println(msg.body)))
 ```
 
@@ -199,7 +199,7 @@ object TestApp extends App {
       _ <- SqsStream(
             client,
             queueUrl,
-            SqsStreamSettings(stopWhenQueueEmpty = true, waitTimeSeconds = 3)
+            SqsStreamSettings(stopWhenQueueEmpty = true, waitTimeSeconds = Some(3))
           ).foreach(msg => UIO(println(msg.body)))
     } yield 0).foldM(e => UIO(println(e.toString)).as(1), IO.succeed)
 }

--- a/src/main/scala/zio/sqs/SqsStream.scala
+++ b/src/main/scala/zio/sqs/SqsStream.scala
@@ -15,14 +15,16 @@ object SqsStream {
     settings: SqsStreamSettings = SqsStreamSettings()
   ): Stream[Throwable, Message] = {
 
-    val request = ReceiveMessageRequest.builder
+    val builder = ReceiveMessageRequest.builder
       .queueUrl(queueUrl)
       .attributeNamesWithStrings(settings.attributeNames.asJava)
       .messageAttributeNames(settings.messageAttributeNames.asJava)
       .maxNumberOfMessages(settings.maxNumberOfMessages)
-      .visibilityTimeout(settings.visibilityTimeout)
-      .waitTimeSeconds(settings.waitTimeSeconds)
-      .build
+
+    settings.visibilityTimeout.foreach(builder.visibilityTimeout(_))
+    settings.waitTimeSeconds.foreach(builder.waitTimeSeconds(_))
+
+    val request = builder.build
 
     Stream.fromEffect {
       Task.effectAsync[List[Message]] { cb =>

--- a/src/main/scala/zio/sqs/SqsStreamSettings.scala
+++ b/src/main/scala/zio/sqs/SqsStreamSettings.scala
@@ -4,8 +4,8 @@ case class SqsStreamSettings(
   attributeNames: List[String] = Nil,
   maxNumberOfMessages: Int = 1,
   messageAttributeNames: List[String] = Nil,
-  visibilityTimeout: Int = 30,
-  waitTimeSeconds: Int = 20,
+  visibilityTimeout: Option[Int] = None,
+  waitTimeSeconds: Option[Int] = None,
   autoDelete: Boolean = true,
   stopWhenQueueEmpty: Boolean = false
 )

--- a/src/main/scala/zio/sqs/SqsStreamSettings.scala
+++ b/src/main/scala/zio/sqs/SqsStreamSettings.scala
@@ -4,8 +4,8 @@ case class SqsStreamSettings(
   attributeNames: List[String] = Nil,
   maxNumberOfMessages: Int = 1,
   messageAttributeNames: List[String] = Nil,
-  visibilityTimeout: Option[Int] = None,
-  waitTimeSeconds: Option[Int] = None,
+  visibilityTimeout: Option[Int] = Some(30),
+  waitTimeSeconds: Option[Int] = Some(20),
   autoDelete: Boolean = true,
   stopWhenQueueEmpty: Boolean = false
 )

--- a/src/test/scala/zio/sqs/ZioSqsSpec.scala
+++ b/src/test/scala/zio/sqs/ZioSqsSpec.scala
@@ -29,7 +29,7 @@ object ZioSqsSpec extends DefaultRunnableSpec {
       },
       testM("delete messages manually") {
         val settings: SqsStreamSettings =
-          SqsStreamSettings(stopWhenQueueEmpty = true, autoDelete = false, waitTimeSeconds = 1)
+          SqsStreamSettings(stopWhenQueueEmpty = true, autoDelete = false, waitTimeSeconds = Some(1))
 
         for {
           messages <- gen.sample.map(_.value).run(Sink.await[List[String]])
@@ -44,7 +44,7 @@ object ZioSqsSpec extends DefaultRunnableSpec {
         } yield assert(list)(isEmpty)
       },
       testM("delete messages automatically") {
-        val settings: SqsStreamSettings = SqsStreamSettings(stopWhenQueueEmpty = true, waitTimeSeconds = 1)
+        val settings: SqsStreamSettings = SqsStreamSettings(stopWhenQueueEmpty = true, waitTimeSeconds = Some(1))
 
         for {
           messages <- gen.sample.map(_.value).run(Sink.await[List[String]])


### PR DESCRIPTION
Closes #253 

I'm not sure what to do with the default values -- I made them `None` for now as it's closer to the usage of the AWS SDK, where the queue's settings as used by default, and the current 30/20 defaults seemed a little arbitrary. On the other hand, if people using the library currently who aren't explicitly setting these in their `SqsStreamSettings` upgrade, their code would still build but their program's behavior could change due to now using the SQS stream's settings. That doesn't seem good, so maybe the defaults should stay as `Some(30)` / `Some(20)`...what do you think?