### PR TITLE
Support delayed delivery of single messages.

### DIFF
--- a/src/main/scala/zio/sqs/producer/Producer.scala
+++ b/src/main/scala/zio/sqs/producer/Producer.scala
@@ -181,6 +181,7 @@ object Producer {
           .messageAttributes(e.event.attributes.asJava)
           .messageGroupId(e.event.groupId.orNull)
           .messageDeduplicationId(e.event.deduplicationId.orNull)
+          .delaySeconds(e.event.delay.map(_.getSeconds).getOrElse(0L).toInt)
           .build()
     }
 

--- a/src/main/scala/zio/sqs/producer/ProducerEvent.scala
+++ b/src/main/scala/zio/sqs/producer/ProducerEvent.scala
@@ -1,5 +1,6 @@
 package zio.sqs.producer
 
+import zio.duration.Duration
 import software.amazon.awssdk.services.sqs.model.MessageAttributeValue
 
 /**
@@ -8,13 +9,15 @@ import software.amazon.awssdk.services.sqs.model.MessageAttributeValue
  * @param attributes a map of [[https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-attributes.html attributes]] to set.
  * @param groupId assigns a specific [[https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagegroupid-property.html message group]] to the message.
  * @param deduplicationId token used for [[https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html deduplication]] of sent messages.
+ * @param delay in order to  [[https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-timers.html delay delivery]] of the message. Allowed values: 0 to 15 minutes.
  * @tparam T type of the payload for the event.
  */
 final case class ProducerEvent[T](
   data: T,
   attributes: Map[String, MessageAttributeValue],
   groupId: Option[String],
-  deduplicationId: Option[String]
+  deduplicationId: Option[String],
+  delay: Option[Duration] = None
 )
 
 object ProducerEvent {
@@ -27,7 +30,8 @@ object ProducerEvent {
       data = body,
       attributes = Map.empty[String, MessageAttributeValue],
       groupId = None,
-      deduplicationId = None
+      deduplicationId = None,
+      delay = None
     )
 
 }

--- a/src/test/scala/zio/sqs/producer/ProducerEventSpec.scala
+++ b/src/test/scala/zio/sqs/producer/ProducerEventSpec.scala
@@ -1,7 +1,9 @@
 package zio.sqs.producer
 
+import java.util.concurrent.TimeUnit
 import software.amazon.awssdk.services.sqs.model.MessageAttributeValue
 import zio.ExecutionStrategy
+import zio.duration.Duration
 import zio.test.Assertion._
 import zio.test._
 import zio.test.environment.TestEnvironment
@@ -21,13 +23,15 @@ object ProducerEventSpec extends DefaultRunnableSpec {
           data = "1",
           attributes = Map("Name" -> attr),
           groupId = Some("2"),
-          deduplicationId = Some("3")
+          deduplicationId = Some("3"),
+          delay = Some(Duration(3, TimeUnit.SECONDS))
         )
 
         assert(e.data)(equalTo("1")) &&
         assert(e.attributes.size)(equalTo(1)) &&
         assert(e.groupId)(isSome(equalTo("2"))) &&
-        assert(e.deduplicationId)(isSome(equalTo("3")))
+        assert(e.deduplicationId)(isSome(equalTo("3"))) &&
+        assert(e.delay)(isSome(equalTo(Duration(3, TimeUnit.SECONDS))))
       },
       test("it can be created from a string") {
         val e = ProducerEvent(


### PR DESCRIPTION

SQS has the ability to delay the delivery of a message.
This PR makes this option available as part of the `ProducerEvent`, which defaults to no delay.