### PR TITLE
Update zio from 1.0.13 to 2.0.0-RC2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,16 +25,17 @@ developers := List(
 
 publishTo := sonatypePublishToBundle.value
 
-val zioAwsVersion = "3.17.100.3"
+val zioVersion = "2.0.0-RC2"
+val zioAwsVersion = "5.17.130.2"
 
 libraryDependencies ++= Seq(
-  "dev.zio"                %% "zio"                     % "1.0.13",
-  "dev.zio"                %% "zio-streams"             % "1.0.13",
-  "io.github.vigoo"        %% "zio-aws-sqs"             % zioAwsVersion,
-  "io.github.vigoo"        %% "zio-aws-netty"           % zioAwsVersion,
+  "dev.zio"                %% "zio"                     % zioVersion,
+  "dev.zio"                %% "zio-streams"             % zioVersion,
+  "dev.zio"                %% "zio-aws-sqs"             % zioAwsVersion,
+  "dev.zio"                %% "zio-aws-netty"           % zioAwsVersion,
   "org.scala-lang.modules" %% "scala-collection-compat" % "2.6.0",
-  "dev.zio"                %% "zio-test"                % "1.0.13" % "test",
-  "dev.zio"                %% "zio-test-sbt"            % "1.0.13" % "test",
+  "dev.zio"                %% "zio-test"                % zioVersion % "test",
+  "dev.zio"                %% "zio-test-sbt"            % zioVersion % "test",
   "org.elasticmq"          %% "elasticmq-rest-sqs"      % "0.15.6" % "test",
   "org.elasticmq"          %% "elasticmq-core"          % "0.15.6" % "test",
   compilerPlugin("org.typelevel" %% "kind-projector"     % "0.10.3"),

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ developers := List(
 
 publishTo := sonatypePublishToBundle.value
 
-val zioVersion = "2.0.0-RC2"
+val zioVersion    = "2.0.0-RC2"
 val zioAwsVersion = "5.17.130.2"
 
 libraryDependencies ++= Seq(
@@ -36,8 +36,8 @@ libraryDependencies ++= Seq(
   "org.scala-lang.modules" %% "scala-collection-compat" % "2.6.0",
   "dev.zio"                %% "zio-test"                % zioVersion % "test",
   "dev.zio"                %% "zio-test-sbt"            % zioVersion % "test",
-  "org.elasticmq"          %% "elasticmq-rest-sqs"      % "0.15.6" % "test",
-  "org.elasticmq"          %% "elasticmq-core"          % "0.15.6" % "test",
+  "org.elasticmq"          %% "elasticmq-rest-sqs"      % "0.15.6"   % "test",
+  "org.elasticmq"          %% "elasticmq-core"          % "0.15.6"   % "test",
   compilerPlugin("org.typelevel" %% "kind-projector"     % "0.10.3"),
   compilerPlugin("com.olegpy"    %% "better-monadic-for" % "0.3.1")
 )

--- a/src/main/scala/zio/sqs/SqsStreamSettings.scala
+++ b/src/main/scala/zio/sqs/SqsStreamSettings.scala
@@ -1,6 +1,6 @@
 package zio.sqs
 
-import io.github.vigoo.zioaws.sqs.model._
+import zio.aws.sqs.model._
 
 case class SqsStreamSettings(
   attributeNames: List[QueueAttributeName] = Nil,

--- a/src/main/scala/zio/sqs/Utils.scala
+++ b/src/main/scala/zio/sqs/Utils.scala
@@ -1,8 +1,7 @@
 package zio.sqs
 
-import io.github.vigoo.zioaws
-import io.github.vigoo.zioaws.sqs.Sqs
-import io.github.vigoo.zioaws.sqs.model.{ CreateQueueRequest, GetQueueUrlRequest, QueueAttributeName }
+import zio.aws.sqs.Sqs
+import zio.aws.sqs.model.{ CreateQueueRequest, GetQueueUrlRequest, QueueAttributeName }
 import zio.RIO
 
 object Utils {
@@ -10,14 +9,14 @@ object Utils {
     name: String,
     attributes: Map[QueueAttributeName, String] = Map()
   ): RIO[Sqs, Unit] =
-    zioaws.sqs
+    zio.aws.sqs.Sqs
       .createQueue(CreateQueueRequest(name, Some(attributes)))
       .mapError(_.toThrowable)
       .unit
 
   def getQueueUrl(name: String): RIO[Sqs, String] =
-    zioaws.sqs
+    zio.aws.sqs.Sqs
       .getQueueUrl(GetQueueUrlRequest(name))
-      .flatMap(_.queueUrl)
+      .flatMap(_.getQueueUrl)
       .mapError(_.toThrowable)
 }

--- a/src/main/scala/zio/sqs/producer/ProducerError.scala
+++ b/src/main/scala/zio/sqs/producer/ProducerError.scala
@@ -1,5 +1,5 @@
 package zio.sqs.producer
-import io.github.vigoo.zioaws.sqs.model.BatchResultErrorEntry
+import zio.aws.sqs.model.BatchResultErrorEntry
 
 /**
  * Encodes an error for the published message
@@ -32,9 +32,9 @@ object ProducerError {
    */
   def apply[T](entry: BatchResultErrorEntry.ReadOnly, event: ProducerEvent[T]): ProducerError[T] =
     ProducerError(
-      senderFault = entry.senderFaultValue,
-      code = entry.codeValue,
-      message = entry.messageValue,
+      senderFault = entry.senderFault,
+      code = entry.code,
+      message = entry.message,
       event = event
     )
 

--- a/src/main/scala/zio/sqs/producer/ProducerEvent.scala
+++ b/src/main/scala/zio/sqs/producer/ProducerEvent.scala
@@ -1,7 +1,7 @@
 package zio.sqs.producer
 
-import io.github.vigoo.zioaws.sqs.model.MessageAttributeValue
-import zio.duration.Duration
+import zio.aws.sqs.model.MessageAttributeValue
+import zio.Duration
 
 /**
  * Event to publish to SQS.

--- a/src/main/scala/zio/sqs/producer/ProducerSettings.scala
+++ b/src/main/scala/zio/sqs/producer/ProducerSettings.scala
@@ -1,6 +1,7 @@
 package zio.sqs.producer
 
-import zio.duration._
+import zio.Duration
+import zio.durationInt
 
 /**
  * Settings for the producer.

--- a/src/test/scala/examples/PublishExample.scala
+++ b/src/test/scala/examples/PublishExample.scala
@@ -1,19 +1,19 @@
 package examples
 
-import io.github.vigoo.zioaws
-import io.github.vigoo.zioaws.sqs.Sqs
-import zio.clock.Clock
+import zio.aws.sqs.Sqs
+import zio.Clock
 import zio.sqs._
 import zio.sqs.producer._
 import zio.sqs.serialization._
 import zio.stream._
 import zio.{ ExitCode, RIO, URIO, ZLayer }
 
-object PublishExample extends zio.App {
+object PublishExample extends zio.ZIOAppDefault {
 
-  val client: ZLayer[Any, Throwable, Sqs] = zioaws.netty.default >>>
-    zioaws.core.config.default >>>
-    zioaws.sqs.live
+  val client: ZLayer[Any, Throwable, Sqs] =
+    zio.aws.netty.NettyHttpClient.default >>>
+      zio.aws.core.config.AwsConfig.default >>>
+      zio.aws.sqs.Sqs.live
 
   val events                                                = List("message1", "message2").map(ProducerEvent(_))
   val queueName                                             = "TestQueue"
@@ -23,6 +23,6 @@ object PublishExample extends zio.App {
     errOrResult <- producer.use(p => p.sendStream(ZStream(events: _*)).runDrain.either)
   } yield errOrResult
 
-  override def run(args: List[String]): URIO[zio.ZEnv, ExitCode] =
+  override def run: URIO[zio.ZEnv, ExitCode] =
     program.provideCustomLayer(client).exitCode
 }

--- a/src/test/scala/examples/TestApp.scala
+++ b/src/test/scala/examples/TestApp.scala
@@ -1,30 +1,30 @@
 package examples
 
-import io.github.vigoo.zioaws
-import io.github.vigoo.zioaws.core.config.CommonAwsConfig
-import io.github.vigoo.zioaws.sqs.Sqs
+import zio.aws.core.config.CommonAwsConfig
+import zio.aws.sqs.Sqs
 import software.amazon.awssdk.auth.credentials.{ AwsBasicCredentials, StaticCredentialsProvider }
 import software.amazon.awssdk.regions.Region
-import zio.clock.Clock
+import zio.Clock
 import zio.sqs.producer.{ Producer, ProducerEvent }
 import zio.sqs.serialization.Serializer
 import zio.sqs.{ SqsStream, SqsStreamSettings, Utils }
 import zio._
 
-object TestApp extends zio.App {
+object TestApp extends zio.ZIOAppDefault {
   val queueName = "TestQueue"
 
-  val client: ZLayer[Any, Throwable, Sqs] = zioaws.netty.default ++
-    ZLayer.succeed(
-      CommonAwsConfig(
-        region = Some(Region.of("ap-northeast-2")),
-        credentialsProvider = StaticCredentialsProvider.create(AwsBasicCredentials.create("key", "key")),
-        endpointOverride = None,
-        commonClientConfig = None
-      )
-    ) >>>
-    zioaws.core.config.configured() >>>
-    zioaws.sqs.live
+  val client: ZLayer[Any, Throwable, Sqs] =
+    zio.aws.netty.NettyHttpClient.default ++
+      ZLayer.succeed(
+        CommonAwsConfig(
+          region = Some(Region.of("ap-northeast-2")),
+          credentialsProvider = StaticCredentialsProvider.create(AwsBasicCredentials.create("key", "key")),
+          endpointOverride = None,
+          commonClientConfig = None
+        )
+      ) >>>
+      zio.aws.core.config.AwsConfig.configured() >>>
+      zio.aws.sqs.Sqs.live
 
   val program: RIO[Sqs with Clock, Unit] = for {
     _        <- Utils.createQueue(queueName)
@@ -39,6 +39,6 @@ object TestApp extends zio.App {
                 ).foreach(msg => UIO(println(msg.body)))
   } yield ()
 
-  override def run(args: List[String]): URIO[zio.ZEnv, ExitCode] =
+  override def run: URIO[zio.ZEnv, ExitCode] =
     program.provideCustomLayer(client).exitCode
 }

--- a/src/test/scala/zio/sqs/Util.scala
+++ b/src/test/scala/zio/sqs/Util.scala
@@ -1,7 +1,7 @@
 package zio.sqs
 
 import zio.Chunk
-import zio.random.Random
+import zio.Random
 import zio.test.{ Gen, Sized }
 
 object Util {

--- a/src/test/scala/zio/sqs/ZioSqsMockServer.scala
+++ b/src/test/scala/zio/sqs/ZioSqsMockServer.scala
@@ -2,13 +2,12 @@ package zio.sqs
 
 import java.net.URI
 
-import io.github.vigoo.zioaws.core.config.AwsConfig
-import io.github.vigoo.zioaws.sqs.Sqs
-import io.github.vigoo.zioaws
+import zio.aws.core.config.AwsConfig
+import zio.aws.sqs.Sqs
 import org.elasticmq.rest.sqs.{ SQSRestServer, SQSRestServerBuilder }
 import software.amazon.awssdk.auth.credentials.{ AwsBasicCredentials, StaticCredentialsProvider }
 import software.amazon.awssdk.regions.Region
-import zio.{ Task, UIO, ZIO, ZLayer, ZManaged }
+import zio.{ Task, UIO, ZLayer, ZManaged }
 
 object ZioSqsMockServer {
   private val staticCredentialsProvider: StaticCredentialsProvider =
@@ -17,12 +16,12 @@ object ZioSqsMockServer {
   private val region: Region                                       = Region.AP_NORTHEAST_2
 
   val serverResource: ZManaged[Any, Throwable, SQSRestServer] =
-    ZManaged.make(
+    ZManaged.acquireReleaseWith(
       Task(SQSRestServerBuilder.start())
-    )(server => UIO.effectTotal(server.stopAndWait()))
+    )(server => UIO.succeed(server.stopAndWait()))
 
   val clientResource: ZLayer[AwsConfig, Throwable, Sqs] =
-    zioaws.sqs.customized(
+    zio.aws.sqs.Sqs.customized(
       _.region(region)
         .credentialsProvider(
           staticCredentialsProvider

--- a/src/test/scala/zio/sqs/ZioSqsSpec.scala
+++ b/src/test/scala/zio/sqs/ZioSqsSpec.scala
@@ -22,7 +22,7 @@ object ZioSqsSpec extends DefaultRunnableSpec {
         val settings: SqsStreamSettings = SqsStreamSettings(stopWhenQueueEmpty = true)
 
         for {
-          messages <- gen.sample.map(_.map(_.value).get).run(Sink.head[Chunk[String]]).someOrFailException
+          messages <- gen.sample.map(_.map(_.value).getOrElse(Chunk.empty)).run(Sink.head[Chunk[String]]).someOrFailException
           list     <- serverResource.use(_ => sendAndGet(messages, settings))
 
         } yield assert(list.map(_.body.getOrElse("")))(equalTo(messages))
@@ -32,7 +32,7 @@ object ZioSqsSpec extends DefaultRunnableSpec {
           SqsStreamSettings(stopWhenQueueEmpty = true, autoDelete = false, waitTimeSeconds = Some(1))
 
         for {
-          messages <- gen.sample.map(_.map(_.value).get).run(Sink.head[Chunk[String]]).someOrFailException
+          messages <- gen.sample.map(_.map(_.value).getOrElse(Chunk.empty)).run(Sink.head[Chunk[String]]).someOrFailException
           list     <- serverResource.use { _ =>
                         for {
                           messageFromQueue <- sendAndGet(messages, settings)
@@ -46,7 +46,7 @@ object ZioSqsSpec extends DefaultRunnableSpec {
         val settings: SqsStreamSettings = SqsStreamSettings(stopWhenQueueEmpty = true, waitTimeSeconds = Some(1))
 
         for {
-          messages <- gen.sample.map(_.map(_.value).get).run(Sink.head[Chunk[String]]).someOrFailException
+          messages <- gen.sample.map(_.map(_.value).getOrElse(Chunk.empty)).run(Sink.head[Chunk[String]]).someOrFailException
           list     <- serverResource.use { _ =>
                         for {
                           _    <- sendAndGet(messages, settings)

--- a/src/test/scala/zio/sqs/ZioSqsSpec.scala
+++ b/src/test/scala/zio/sqs/ZioSqsSpec.scala
@@ -1,39 +1,38 @@
 package zio.sqs
 
-import io.github.vigoo.zioaws
-import io.github.vigoo.zioaws.sqs.Sqs
-import io.github.vigoo.zioaws.sqs.model.Message
+import zio.aws.sqs.Sqs
+import zio.aws.sqs.model.Message
 import zio._
-import zio.clock.Clock
-import zio.duration._
-import zio.random.Random
+import zio.Clock
+import zio.durationInt
+import zio.Random
 import zio.sqs.ZioSqsMockServer._
 import zio.sqs.producer.{ Producer, ProducerEvent }
 import zio.sqs.serialization.Serializer
 import zio.stream.Sink
 import zio.test.Assertion._
 import zio.test._
-import zio.test.environment.{ Live, TestClock, TestEnvironment }
+import zio.test.{ Live, TestClock, TestEnvironment }
 
 object ZioSqsSpec extends DefaultRunnableSpec {
 
   def spec: ZSpec[TestEnvironment, Any] =
     suite("ZioSqsSpec")(
-      testM("send messages") {
+      test("send messages") {
         val settings: SqsStreamSettings = SqsStreamSettings(stopWhenQueueEmpty = true)
 
         for {
-          messages <- gen.sample.map(_.value).run(Sink.head[Chunk[String]]).someOrFailException
+          messages <- gen.sample.map(_.map(_.value).get).run(Sink.head[Chunk[String]]).someOrFailException
           list     <- serverResource.use(_ => sendAndGet(messages, settings))
 
-        } yield assert(list.map(_.bodyValue.getOrElse("")))(equalTo(messages))
+        } yield assert(list.map(_.body.getOrElse("")))(equalTo(messages))
       },
-      testM("delete messages manually") {
+      test("delete messages manually") {
         val settings: SqsStreamSettings =
           SqsStreamSettings(stopWhenQueueEmpty = true, autoDelete = false, waitTimeSeconds = Some(1))
 
         for {
-          messages <- gen.sample.map(_.value).run(Sink.head[Chunk[String]]).someOrFailException
+          messages <- gen.sample.map(_.map(_.value).get).run(Sink.head[Chunk[String]]).someOrFailException
           list     <- serverResource.use { _ =>
                         for {
                           messageFromQueue <- sendAndGet(messages, settings)
@@ -43,11 +42,11 @@ object ZioSqsSpec extends DefaultRunnableSpec {
 
         } yield assert(list)(isEmpty)
       },
-      testM("delete messages automatically") {
+      test("delete messages automatically") {
         val settings: SqsStreamSettings = SqsStreamSettings(stopWhenQueueEmpty = true, waitTimeSeconds = Some(1))
 
         for {
-          messages <- gen.sample.map(_.value).run(Sink.head[Chunk[String]]).someOrFailException
+          messages <- gen.sample.map(_.map(_.value).get).run(Sink.head[Chunk[String]]).someOrFailException
           list     <- serverResource.use { _ =>
                         for {
                           _    <- sendAndGet(messages, settings)
@@ -56,7 +55,7 @@ object ZioSqsSpec extends DefaultRunnableSpec {
                       }
         } yield assert(list)(isEmpty)
       }
-    ).provideCustomLayerShared((zioaws.netty.default >>> zioaws.core.config.default >>> clientResource).orDie)
+    ).provideCustomLayerShared((zio.aws.netty.NettyHttpClient.default >>> zio.aws.core.config.AwsConfig.default >>> clientResource).orDie)
 
   override def aspects: List[TestAspect[Nothing, TestEnvironment, Nothing, Any]] =
     List(TestAspect.executionStrategy(ExecutionStrategy.Sequential))
@@ -66,7 +65,7 @@ object ZioSqsSpec extends DefaultRunnableSpec {
   val gen: Gen[Random with Sized, Chunk[String]] = Util.chunkOfStringsN(10)
 
   def withFastClock: ZIO[TestClock with Live, Nothing, Long] =
-    Live.withLive(TestClock.adjust(1.seconds))(_.repeat(Schedule.spaced(10.millis)))
+    Live.withLive(TestClock.adjust(1.seconds))(_.repeat[ZEnv, Long](Schedule.spaced(10.millis)))
 
   def sendAndGet(messages: Seq[String], settings: SqsStreamSettings): ZIO[TestClock with Live with Clock with Sqs, Throwable, Chunk[Message.ReadOnly]] =
     for {
@@ -81,7 +80,7 @@ object ZioSqsSpec extends DefaultRunnableSpec {
   def deleteAndGet(messages: Seq[Message.ReadOnly], settings: SqsStreamSettings): ZIO[Sqs, Throwable, Chunk[Message.ReadOnly]] =
     for {
       queueUrl <- Utils.getQueueUrl(queueName)
-      _        <- ZIO.foreach_(messages)(SqsStream.deleteMessage(queueUrl, _))
+      _        <- ZIO.foreachDiscard(messages)(SqsStream.deleteMessage(queueUrl, _))
       list     <- SqsStream(queueUrl, settings).runCollect
     } yield list
 

--- a/src/test/scala/zio/sqs/ZioSqsSpec.scala
+++ b/src/test/scala/zio/sqs/ZioSqsSpec.scala
@@ -21,7 +21,7 @@ object ZioSqsSpec extends DefaultRunnableSpec {
         val settings: SqsStreamSettings = SqsStreamSettings(stopWhenQueueEmpty = true)
 
         for {
-          messages <- gen.sample.map(_.map(_.value)).runHead.map(_.flatten).someOrFailException
+          messages <- gen.runHead.someOrFailException
           list     <- serverResource.use(_ => sendAndGet(messages, settings))
 
         } yield assert(list.map(_.body.getOrElse("")))(equalTo(messages))
@@ -31,7 +31,7 @@ object ZioSqsSpec extends DefaultRunnableSpec {
           SqsStreamSettings(stopWhenQueueEmpty = true, autoDelete = false, waitTimeSeconds = Some(1))
 
         for {
-          messages <- gen.sample.map(_.map(_.value)).runHead.map(_.flatten).someOrFailException
+          messages <- gen.runHead.someOrFailException
           list     <- serverResource.use { _ =>
                         for {
                           messageFromQueue <- sendAndGet(messages, settings)
@@ -45,7 +45,7 @@ object ZioSqsSpec extends DefaultRunnableSpec {
         val settings: SqsStreamSettings = SqsStreamSettings(stopWhenQueueEmpty = true, waitTimeSeconds = Some(1))
 
         for {
-          messages <- gen.sample.map(_.map(_.value)).runHead.map(_.flatten).someOrFailException
+          messages <- gen.runHead.someOrFailException
           list     <- serverResource.use { _ =>
                         for {
                           _    <- sendAndGet(messages, settings)

--- a/src/test/scala/zio/sqs/producer/ProducerErrorSpec.scala
+++ b/src/test/scala/zio/sqs/producer/ProducerErrorSpec.scala
@@ -1,10 +1,10 @@
 package zio.sqs.producer
 
-import io.github.vigoo.zioaws.sqs.model.BatchResultErrorEntry
+import zio.aws.sqs.model.BatchResultErrorEntry
 import zio.ExecutionStrategy
 import zio.test.Assertion._
 import zio.test._
-import zio.test.environment.TestEnvironment
+import zio.test.TestEnvironment
 
 object ProducerErrorSpec extends DefaultRunnableSpec {
 

--- a/src/test/scala/zio/sqs/producer/ProducerEventSpec.scala
+++ b/src/test/scala/zio/sqs/producer/ProducerEventSpec.scala
@@ -2,12 +2,12 @@ package zio.sqs.producer
 
 import java.util.concurrent.TimeUnit
 
-import io.github.vigoo.zioaws.sqs.model.MessageAttributeValue
+import zio.aws.sqs.model.MessageAttributeValue
 import zio.ExecutionStrategy
-import zio.duration.Duration
+import zio.Duration
 import zio.test.Assertion._
 import zio.test._
-import zio.test.environment.TestEnvironment
+import zio.test.TestEnvironment
 
 object ProducerEventSpec extends DefaultRunnableSpec {
 

--- a/src/test/scala/zio/sqs/producer/ProducerSpec.scala
+++ b/src/test/scala/zio/sqs/producer/ProducerSpec.scala
@@ -3,13 +3,11 @@ package zio.sqs.producer
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
 
-import io.github.vigoo.zioaws
-import io.github.vigoo.zioaws.core.{ aspects, AwsError }
-import io.github.vigoo.zioaws.sqs.model._
-import io.github.vigoo.zioaws.sqs.{ model, Sqs }
+import zio.aws.core.{ aspects, AwsError }
+import zio.aws.sqs.model._
+import zio.aws.sqs.{ model, Sqs }
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
-import zio.clock._
-import zio.duration._
+import zio.durationInt
 import zio.sqs.ZioSqsMockServer._
 import zio.sqs.producer.Producer.{ DefaultProducer, SqsRequest, SqsRequestEntry, SqsResponseErrorEntry }
 import zio.sqs.serialization.Serializer
@@ -17,7 +15,7 @@ import zio.sqs.{ Util, Utils }
 import zio.stream.{ Sink, Stream, ZStream }
 import zio.test.Assertion._
 import zio.test._
-import zio.test.environment.{ Live, TestClock, TestEnvironment }
+import zio.test.{ Live, TestClock, TestEnvironment }
 import zio.{ test => _, _ }
 
 import scala.language.implicitConversions
@@ -37,7 +35,7 @@ object ProducerSpec extends DefaultRunnableSpec {
         assert(Producer.nextPower2(129))(equalTo(256)) &&
         assert(Producer.nextPower2(257))(equalTo(512))
       },
-      testM("SqsRequestEntry can be created") {
+      test("SqsRequestEntry can be created") {
         val attr = MessageAttributeValue(Some("Bob"), dataType = "String")
 
         val pe = ProducerEvent(
@@ -55,7 +53,7 @@ object ProducerSpec extends DefaultRunnableSpec {
           assert(isDone)(isFalse) &&
           assert(requestEntry.retryCount)(equalTo(10))
       },
-      testM("SqsRequest can be created") {
+      test("SqsRequest can be created") {
         val attr = MessageAttributeValue(Some("Bob"), dataType = "String")
 
         val pe = ProducerEvent(
@@ -76,7 +74,7 @@ object ProducerSpec extends DefaultRunnableSpec {
         } yield assert(request.inner)(equalTo(batchReq)) &&
           assert(request.entries)(equalTo(List(requestEntry)))
       },
-      testM("SqsResponseErrorEntry can be created") {
+      test("SqsResponseErrorEntry can be created") {
         val event    = ProducerEvent("e1")
         val errEntry = BatchResultErrorEntry(id = "id1", senderFault = true, code = "code2", message = Some("message3"))
 
@@ -89,7 +87,7 @@ object ProducerSpec extends DefaultRunnableSpec {
         } yield assert(errEntry.error)(equalTo(eventError)) &&
           assert(isDone)(isFalse)
       },
-      testM("SendMessageBatchResponse can be partitioned") {
+      test("SendMessageBatchResponse can be partitioned") {
         val retryMaxCount = 10
         val rs            = Range(0, 4).toList
         val ids           = rs.map(_.toString)
@@ -110,7 +108,7 @@ object ProducerSpec extends DefaultRunnableSpec {
           assert(retryable.size)(equalTo(1)) &&
           assert(errors.size)(equalTo(2))
       },
-      testM("SendMessageBatchResponse can be partitioned and mapped") {
+      test("SendMessageBatchResponse can be partitioned and mapped") {
         val retryMaxCount = 10
         val rs            = Range(0, 4).toList
         val ids           = rs.map(_.toString)
@@ -140,7 +138,7 @@ object ProducerSpec extends DefaultRunnableSpec {
           assert(retryableEntries.toList.map(_.event.data))(hasSameElements(List("B"))) &&
           assert(errorsEntries.toList.map(_.error.event.data))(hasSameElements(List("C", "D")))
       },
-      testM("buildSendMessageBatchRequest creates a new request") {
+      test("buildSendMessageBatchRequest creates a new request") {
         val queueUrl = "sqs://queue"
 
         val attr = MessageAttributeValue(Some("Bob"), dataType = "String")
@@ -189,18 +187,18 @@ object ProducerSpec extends DefaultRunnableSpec {
           assert(innerReqEntries(1).messageDeduplicationId)(isSome(equalTo("d2")))
         }
       },
-      testM("runSendMessageBatchRequest can be executed") {
+      test("runSendMessageBatchRequest can be executed") {
         val queueName                  = "runSendMessageBatchRequest-" + UUID.randomUUID().toString
         val settings: ProducerSettings = ProducerSettings()
         val eventCount                 = settings.batchSize
         for {
           events     <- Util.chunkOfStringsN(eventCount)
                           .sample
-                          .map(_.value.map(ProducerEvent(_)))
+                          .map(_.get.value.map(ProducerEvent(_)))
                           .run(Sink.head[Chunk[ProducerEvent[String]]])
                           .someOrFailException
           retryQueue <- queueResource(16)
-          dones      <- serverResource.use_ {
+          dones      <- serverResource.useDiscard {
                           retryQueue.use {
                             q =>
                               for {
@@ -222,7 +220,7 @@ object ProducerSpec extends DefaultRunnableSpec {
           isAllRight <- dones.map(_.forall(_.isRight))
         } yield assert(isAllRight)(isTrue)
       },
-      testM("events can be published using sendStream and return the results") {
+      test("events can be published using sendStream and return the results") {
         val queueName                  = "sendStream-" + UUID.randomUUID().toString
         val settings: ProducerSettings = ProducerSettings()
         val eventCount                 = (settings.batchSize * 2) + 3
@@ -231,10 +229,10 @@ object ProducerSpec extends DefaultRunnableSpec {
           events  <- Util
                        .chunkOfStringsN(eventCount)
                        .sample
-                       .map(_.value.map(ProducerEvent(_)))
+                       .map(_.get.value.map(ProducerEvent(_)))
                        .run(Sink.head[Chunk[ProducerEvent[String]]])
                        .someOrFailException
-          results <- serverResource.use_ {
+          results <- serverResource.useDiscard {
                        for {
                          _           <- withFastClock.fork
                          _           <- Utils.createQueue(queueName)
@@ -251,7 +249,7 @@ object ProducerSpec extends DefaultRunnableSpec {
         } yield assert(results.size)(equalTo(events.size)) &&
           assert(results.forall(_.isRight))(isTrue)
       },
-      testM("events can be published using sendStream and fail the task on error") {
+      test("events can be published using sendStream and fail the task on error") {
         val queueName                  = "produce-" + UUID.randomUUID().toString
         val queueUrl                   = s"sqs://$queueName"
         val settings: ProducerSettings = ProducerSettings()
@@ -264,7 +262,7 @@ object ProducerSpec extends DefaultRunnableSpec {
           errOrResult <- producer.use(p => p.sendStream(Stream(events: _*)).runDrain.either)
         } yield assert(errOrResult.isLeft)(isTrue)
       },
-      testM("events can be published using produce and return the results") {
+      test("events can be published using produce and return the results") {
         val queueName                  = "produce-" + UUID.randomUUID().toString
         val settings: ProducerSettings = ProducerSettings()
         val eventCount                 = settings.batchSize
@@ -273,10 +271,10 @@ object ProducerSpec extends DefaultRunnableSpec {
           events  <- Util
                        .chunkOfStringsN(eventCount)
                        .sample
-                       .map(_.value.map(ProducerEvent(_)))
+                       .map(_.get.value.map(ProducerEvent(_)))
                        .run(Sink.head[Chunk[ProducerEvent[String]]])
                        .someOrFailException
-          results <- serverResource.use_ {
+          results <- serverResource.useDiscard {
                        for {
                          _        <- withFastClock.fork
                          _        <- Utils.createQueue(queueName)
@@ -288,7 +286,7 @@ object ProducerSpec extends DefaultRunnableSpec {
         } yield assert(results.size)(equalTo(events.size)) &&
           assert(results.forall(_.isRight))(isTrue)
       },
-      testM("events can be pushed using produce and fail the task on error") {
+      test("events can be pushed using produce and fail the task on error") {
         val queueName                  = "produce-" + UUID.randomUUID().toString
         val queueUrl                   = s"sqs://$queueName"
         val settings: ProducerSettings = ProducerSettings()
@@ -301,7 +299,7 @@ object ProducerSpec extends DefaultRunnableSpec {
           errOrResults <- producer.use(p => ZIO.foreachPar(events)(event => p.produce(event))).either
         } yield assert(errOrResults.isLeft)(isTrue)
       },
-      testM("events can be published using produceBatch and return the results") {
+      test("events can be published using produceBatch and return the results") {
         val queueName                  = "produceBatch-" + UUID.randomUUID().toString
         val settings: ProducerSettings = ProducerSettings()
         val eventCount                 = settings.batchSize * 2
@@ -310,10 +308,10 @@ object ProducerSpec extends DefaultRunnableSpec {
           events  <- Util
                        .chunkOfStringsN(eventCount)
                        .sample
-                       .map(_.value.map(ProducerEvent(_)))
+                       .map(_.get.value.map(ProducerEvent(_)))
                        .run(Sink.head[Chunk[ProducerEvent[String]]])
                        .someOrFailException
-          results <- serverResource.use_ {
+          results <- serverResource.useDiscard {
                        for {
                          _        <- withFastClock.fork
                          _        <- Utils.createQueue(queueName)
@@ -325,7 +323,7 @@ object ProducerSpec extends DefaultRunnableSpec {
         } yield assert(results.size)(equalTo(events.size)) &&
           assert(results.forall(_.isRight))(isTrue)
       },
-      testM("events can be published using produceBatch and fail the task on error") {
+      test("events can be published using produceBatch and fail the task on error") {
         val queueName                  = "produceBatch-" + UUID.randomUUID().toString
         val queueUrl                   = s"sqs://$queueName"
         val settings: ProducerSettings = ProducerSettings()
@@ -338,7 +336,7 @@ object ProducerSpec extends DefaultRunnableSpec {
           errOrResults <- producer.use(p => p.produceBatch(events)).either
         } yield assert(errOrResults.isLeft)(isTrue)
       },
-      testM("events can be published using sendSink") {
+      test("events can be published using sendSink") {
         val queueName                  = "sendSink-" + UUID.randomUUID().toString
         val settings: ProducerSettings = ProducerSettings()
         val eventCount                 = settings.batchSize
@@ -347,10 +345,10 @@ object ProducerSpec extends DefaultRunnableSpec {
           events  <- Util
                        .chunkOfStringsN(eventCount)
                        .sample
-                       .map(_.value.map(ProducerEvent(_)))
+                       .map(_.get.value.map(ProducerEvent(_)))
                        .run(Sink.head[Chunk[ProducerEvent[String]]])
                        .someOrFailException
-          results <- serverResource.use_ {
+          results <- serverResource.useDiscard {
                        for {
                          _        <- withFastClock.fork
                          _        <- Utils.createQueue(queueName)
@@ -361,7 +359,7 @@ object ProducerSpec extends DefaultRunnableSpec {
                      }
         } yield assert(results)(equalTo(()))
       },
-      testM("events that published using sendSink and generate an exception on send should fail the sink") {
+      test("events that published using sendSink and generate an exception on send should fail the sink") {
         val queueName                  = "sendSink-" + UUID.randomUUID().toString
         val queueUrl                   = s"sqs://$queueName"
         val settings: ProducerSettings = ProducerSettings()
@@ -382,7 +380,7 @@ object ProducerSpec extends DefaultRunnableSpec {
           errOrResults <- producer.use(p => Stream.succeed(events).run(p.sendSink)).either
         } yield assert(errOrResults.isLeft)(isTrue)
       },
-      testM("events that published using sendSink and return an unrecoverable error should fail the sink on error") {
+      test("events that published using sendSink and return an unrecoverable error should fail the sink on error") {
         val queueName                  = "sendSink-" + UUID.randomUUID().toString
         val queueUrl                   = s"sqs://$queueName"
         val settings: ProducerSettings = ProducerSettings()
@@ -395,7 +393,7 @@ object ProducerSpec extends DefaultRunnableSpec {
           errOrResults <- producer.use(p => Stream.succeed(events).run(p.sendSink)).either
         } yield assert(errOrResults.isLeft)(isTrue)
       },
-      testM("submitted events can succeed and fail if there are unrecoverable errors") {
+      test("submitted events can succeed and fail if there are unrecoverable errors") {
         val queueName                  = "success-and-unrecoverable-failures-" + UUID.randomUUID().toString
         val queueUrl                   = s"sqs://$queueName"
         val settings: ProducerSettings = ProducerSettings()
@@ -440,7 +438,7 @@ object ProducerSpec extends DefaultRunnableSpec {
           assert(failures)(hasSameElements(List("B", "C")))
         }
       },
-      testM("submitted events can be republished if there are recoverable errors") {
+      test("submitted events can be republished if there are recoverable errors") {
         val queueName                  = "success-and-recoverable-failures-" + UUID.randomUUID().toString
         val queueUrl                   = s"sqs://$queueName"
         val settings: ProducerSettings = ProducerSettings()
@@ -452,7 +450,7 @@ object ProducerSpec extends DefaultRunnableSpec {
             override def sendMessageBatch(
               request: SendMessageBatchRequest
             ): IO[AwsError, SendMessageBatchResponse.ReadOnly] =
-              IO.effectTotal {
+              IO.succeed {
                 invokeCount.incrementAndGet()
 
                 val batchRequestEntries                                       = request.entries
@@ -483,7 +481,7 @@ object ProducerSpec extends DefaultRunnableSpec {
           assert(invokeCount.get())(isGreaterThanEqualTo(2))
         }
       },
-      testM("if the number of recoverable retries exceeds the limit, messages fail") {
+      test("if the number of recoverable retries exceeds the limit, messages fail") {
         val queueName                  = "fail-when-retry-limit-reached-" + UUID.randomUUID().toString
         val queueUrl                   = s"sqs://$queueName"
         val settings: ProducerSettings = ProducerSettings()
@@ -524,7 +522,7 @@ object ProducerSpec extends DefaultRunnableSpec {
           assert(invokeCount.get())(equalTo((settings.retryMaxCount + 1) * events.size))
         }
       },
-      testM("a SendMessageBatchRequest failed with an exception should fail") {
+      test("a SendMessageBatchRequest failed with an exception should fail") {
         val queueName                  = "fail-with-exception-" + UUID.randomUUID().toString
         val queueUrl                   = s"sqs://$queueName"
         val settings: ProducerSettings = ProducerSettings()
@@ -545,7 +543,7 @@ object ProducerSpec extends DefaultRunnableSpec {
           errOrResults <- producer.use(p => p.produceBatchE(events)).either
         } yield assert(errOrResults.isLeft)(isTrue)
       },
-      testM("several SendMessageBatchRequest failed with an exception should not stop the producer (#456)") {
+      test("several SendMessageBatchRequest failed with an exception should not stop the producer (#456)") {
         val queueName                  = "fail-with-exception-" + UUID.randomUUID().toString
         val queueUrl                   = s"sqs://$queueName"
         val settings: ProducerSettings = ProducerSettings(batchSize = 1, parallelism = 1, duration = 1.milliseconds)
@@ -569,25 +567,25 @@ object ProducerSpec extends DefaultRunnableSpec {
         for {
           _       <- withFastClock.fork
           producer = Producer.make(queueUrl, Serializer.serializeString, settings).provideCustomLayer(client)
-          results <- producer.use(p => ZIO.foreach(events)(e => sleep(100.milliseconds) *> p.produce(e).either))
+          results <- producer.use(p => ZIO.foreach(events)(e => ZIO.sleep(100.milliseconds) *> p.produce(e).either))
         } yield {
           val (failures, successes) = results.partition(_.isLeft)
           assert(successes.collect({ case Right(x) => x.data }))(hasSameElements(List("C", "E"))) &&
           assert(failures.size)(equalTo(3))
         }
       }
-    ).provideCustomLayerShared((zioaws.netty.default >>> zioaws.core.config.default >>> clientResource).orDie)
+    ).provideCustomLayerShared((zio.aws.netty.NettyHttpClient.default >>> zio.aws.core.config.AwsConfig.default >>> clientResource).orDie)
 
   override def aspects: List[TestAspect[Nothing, TestEnvironment, Nothing, Any]] =
     List(TestAspect.executionStrategy(ExecutionStrategy.Sequential))
 
   def queueResource(capacity: Int): Task[ZManaged[Any, Throwable, Queue[SqsRequestEntry[String]]]] =
     Task.succeed {
-      Queue.bounded[SqsRequestEntry[String]](capacity).toManaged(_.shutdown)
+      Queue.bounded[SqsRequestEntry[String]](capacity).toManagedWith(_.shutdown)
     }
 
   def withFastClock: ZIO[TestClock with Live, Nothing, Long] =
-    Live.withLive(TestClock.adjust(1.seconds))(_.repeat(Schedule.spaced(10.millis)))
+    Live.withLive(TestClock.adjust(1.seconds))(_.repeat[ZEnv, Long](Schedule.spaced(10.millis)))
 
   /**
    * A client that fails all incoming messages in the batch with unrecoverable error.
@@ -607,11 +605,12 @@ object ProducerSpec extends DefaultRunnableSpec {
   }
 }
 
-class StubSqsService extends Sqs.Service {
+class StubSqsService extends Sqs {
   override lazy val api: SqsAsyncClient                                                                                                                      = ???
   override def getQueueAttributes(request: model.GetQueueAttributesRequest): IO[AwsError, GetQueueAttributesResponse.ReadOnly]                               = ???
   override def sendMessage(request: model.SendMessageRequest): IO[AwsError, SendMessageResponse.ReadOnly]                                                    = ???
   override def listQueues(request: model.ListQueuesRequest): ZStream[Any, AwsError, String]                                                                  = ???
+  override def listQueuesPaginated(request: model.ListQueuesRequest): ZIO[Any, AwsError, ListQueuesResponse.ReadOnly]                                        = ???
   override def untagQueue(request: model.UntagQueueRequest): IO[AwsError, Unit]                                                                              = ???
   override def tagQueue(request: model.TagQueueRequest): IO[AwsError, Unit]                                                                                  = ???
   override def deleteMessage(request: model.DeleteMessageRequest): IO[AwsError, Unit]                                                                        = ???
@@ -621,6 +620,9 @@ class StubSqsService extends Sqs.Service {
   override def listQueueTags(request: model.ListQueueTagsRequest): IO[AwsError, ListQueueTagsResponse.ReadOnly]                                              = ???
   override def createQueue(request: CreateQueueRequest): IO[AwsError, CreateQueueResponse.ReadOnly]                                                          = ???
   override def listDeadLetterSourceQueues(request: model.ListDeadLetterSourceQueuesRequest): ZStream[Any, AwsError, String]                                  = ???
+  override def listDeadLetterSourceQueuesPaginated(
+    request: model.ListDeadLetterSourceQueuesRequest
+  ): ZIO[Any, AwsError, ListDeadLetterSourceQueuesResponse.ReadOnly]                                                                                         = ???
   override def getQueueUrl(request: GetQueueUrlRequest): IO[AwsError, GetQueueUrlResponse.ReadOnly]                                                          = ???
   override def removePermission(request: model.RemovePermissionRequest): IO[AwsError, Unit]                                                                  = ???
   override def receiveMessage(request: model.ReceiveMessageRequest): IO[AwsError, ReceiveMessageResponse.ReadOnly]                                           = ???
@@ -630,5 +632,5 @@ class StubSqsService extends Sqs.Service {
   override def changeMessageVisibilityBatch(request: model.ChangeMessageVisibilityBatchRequest): IO[AwsError, ChangeMessageVisibilityBatchResponse.ReadOnly] =
     ???
   override def changeMessageVisibility(request: model.ChangeMessageVisibilityRequest): IO[AwsError, Unit]                                                    = ???
-  override def withAspect[R](newAspect: aspects.AwsCallAspect[R], r: R): Sqs.Service                                                                         = ???
+  override def withAspect[R](newAspect: aspects.AwsCallAspect[R], r: ZEnvironment[R]): Sqs                                                                   = ???
 }

--- a/src/test/scala/zio/sqs/producer/ProducerSpec.scala
+++ b/src/test/scala/zio/sqs/producer/ProducerSpec.scala
@@ -552,7 +552,7 @@ object ProducerSpec extends DefaultRunnableSpec {
         val client: ULayer[Sqs] = ZLayer.succeed {
           new StubSqsService {
             override def sendMessageBatch(request: SendMessageBatchRequest): IO[AwsError, SendMessageBatchResponse.ReadOnly] =
-              if (List("C", "E").contains(request.entries.head.messageBody))
+              if (request.entries.isEmpty || List("C", "E").contains(request.entries.head.messageBody))
                 ZIO.succeed {
                   val batchRequestEntries = request.entries
                   val resultEntries       = batchRequestEntries.map(entry => SendMessageBatchResultEntry(entry.id, "", ""))

--- a/src/test/scala/zio/sqs/serialization/SerializerSpec.scala
+++ b/src/test/scala/zio/sqs/serialization/SerializerSpec.scala
@@ -3,7 +3,7 @@ package zio.sqs.serialization
 import zio.ExecutionStrategy
 import zio.test.Assertion._
 import zio.test._
-import zio.test.environment.TestEnvironment
+import zio.test.TestEnvironment
 
 object SerializerSpec extends DefaultRunnableSpec {
 


### PR DESCRIPTION
**TODO:**

* [x] Fix compile errors
* [x] Fix compile warnings
* [x] Fix linting failures
* [x] Fix hanging tests
    * [x] `zio.sqs.ZioSqsSpec`
    * [x] `zio.sqs.producer.ProducerErrorSpec`
    * [x] `zio.sqs.producer.ProducerEventSpec`
    * [x] `zio.sqs.producer.ProducerSpec`
        * [x] `nextPower2 can be calculated`
        * [x] `SqsRequestEntry can be created`
        * [x] `SqsRequest can be created`
        * [x] `SqsResponseErrorEntry can be created`
        * [x] `SendMessageBatchResponse can be partitioned`
        * [x] `SendMessageBatchResponse can be partitioned and mapped`
        * [x] `buildSendMessageBatchRequest creates a new request`
        * [x] `runSendMessageBatchRequest can be executed`
        * [x] `events can be published using sendStream and return the results`
        * [x] `events can be published using sendStream and fail the task on error`
        * [x] `events can be published using produce and return the results`
        * [x] `events can be pushed using produce and fail the task on error`
        * [x] `events can be published using produceBatch and return the results`
        * [x] `events can be published using produceBatch and fail the task on error`
        * [x] `events can be published using sendSink`
        * [x] `events that published using sendSink and generate an exception on send should fail the sink`
        * [x] `events that published using sendSink and return an unrecoverable error should fail the sink on error`
        * [x] `submitted events can succeed and fail if there are unrecoverable errors`
        * [x] `submitted events can be republished if there are recoverable errors`
        * [x] `if the number of recoverable retries exceeds the limit, messages fail`
        * [x] `a SendMessageBatchRequest failed with an exception should fail`
        * [x] `several SendMessageBatchRequest failed with an exception should not stop the producer (#456)`
            * Hangs on [`p.produce(e)`](https://github.com/zio/zio-sqs/blob/896ca6d/src/test/scala/zio/sqs/producer/ProducerSpec.scala#L570)
            * ~~Possible regression of #456~~
    * [x] `zio.sqs.serialization.SerializerSpec`