### PR TITLE
Scala3 Support using 2.13 ElasticMq

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         java: ['adopt@1.8', 'adopt@1.11']
-        scala: ['2.12.16', '2.13.8']
+        scala: ['2.12.16', '2.13.10', '3.2.1']
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v2.3.4

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
-val mainScala     = "2.13.8"
-val allScala      = Seq(mainScala, "2.12.16")
+val mainScala     = "3.2.1"
+val allScala      = Seq("3.2.1", "2.13.10", "2.12.16")
 val zioVersion    = "2.0.0"
 val zioAwsVersion = "5.17.224.4"
 
@@ -59,30 +59,31 @@ lazy val sqs =
         "org.scala-lang.modules" %% "scala-collection-compat" % "2.8.0",
         "dev.zio"                %% "zio-test"                % zioVersion % "test",
         "dev.zio"                %% "zio-test-sbt"            % zioVersion % "test",
-        "org.elasticmq"          %% "elasticmq-rest-sqs"      % "1.3.7"    % "test",
-        "org.elasticmq"          %% "elasticmq-core"          % "1.3.7"    % "test",
-        compilerPlugin("org.typelevel" %% "kind-projector"     % "0.10.3"),
-        compilerPlugin("com.olegpy"    %% "better-monadic-for" % "0.3.1")
-      ),
+        "org.elasticmq"          %% "elasticmq-rest-sqs"      % "1.3.7"    % "test" cross CrossVersion.for3Use2_13,
+        "org.elasticmq"          %% "elasticmq-core"          % "1.3.7"    % "test" cross CrossVersion.for3Use2_13
+      ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, 12)) =>
+          Seq("org.typelevel" %% "kind-projector" % "0.10.3")
+        case Some((2, 13)) =>
+          Seq("org.typelevel" %% "kind-projector" % "0.10.3")
+        case _             =>
+          Nil
+      }),
       scalacOptions ++= Seq(
         "-deprecation",
         "-encoding",
         "UTF-8",
         "-explaintypes",
-        "-Yrangepos",
         "-feature",
         "-language:higherKinds",
         "-language:existentials",
-        "-unchecked",
-        "-Xlint:_,-type-parameter-shadow",
-        "-Ywarn-numeric-widen",
-        "-Ywarn-unused",
-        "-Ywarn-value-discard"
+        "-unchecked"
       ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, 12)) =>
           Seq(
             "-Xfuture",
             "-Xsource:2.13",
+            "-Xlint:_,-type-parameter-shadow",
             "-Yno-adapted-args",
             "-Ypartial-unification",
             "-Ywarn-extra-implicit",
@@ -90,9 +91,22 @@ lazy val sqs =
             "-Ywarn-infer-any",
             "-Ywarn-nullary-override",
             "-Ywarn-nullary-unit",
+            "-Yrangepos",
+            "-Ywarn-numeric-widen",
+            "-Ywarn-unused",
+            "-Ywarn-value-discard",
             "-opt-inline-from:<source>",
             "-opt-warnings",
             "-opt:l:inline"
+          )
+        case Some((2, 13)) =>
+          Seq(
+            "-Xlint:_,-type-parameter-shadow",
+            "-Werror",
+            "-Yrangepos",
+            "-Ywarn-numeric-widen",
+            "-Ywarn-unused",
+            "-Ywarn-value-discard"
           )
         case _             => Nil
       }),

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val mainScala     = "3.2.1"
+val mainScala     = "2.3.10"
 val allScala      = Seq("3.2.1", "2.13.10", "2.12.16")
 val zioVersion    = "2.0.0"
 val zioAwsVersion = "5.17.224.4"

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val mainScala     = "2.3.10"
+val mainScala     = "2.13.10"
 val allScala      = Seq("3.2.1", "2.13.10", "2.12.16")
 val zioVersion    = "2.0.0"
 val zioAwsVersion = "5.17.224.4"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.1
+sbt.version=1.8.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,4 +2,4 @@ addSbtPlugin("org.scalameta"  % "sbt-scalafmt"    % "2.4.3")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release"  % "1.5.10")
 addSbtPlugin("dev.zio"        % "zio-sbt-website" % "0.3.2")
 
-resolvers += Resolver.sonatypeRepo("public")
+resolvers ++= Resolver.sonatypeOssRepos("public")

--- a/zio-sqs/src/main/scala/zio/sqs/producer/Producer.scala
+++ b/zio-sqs/src/main/scala/zio/sqs/producer/Producer.scala
@@ -3,7 +3,6 @@ package zio.sqs.producer
 import zio.aws.sqs.Sqs
 import zio.aws.sqs.model._
 import zio._
-import zio.Clock
 import zio.Duration
 import zio.sqs.serialization.Serializer
 import zio.stream.{ Stream, ZSink, ZStream }

--- a/zio-sqs/src/test/scala/zio/sqs/ZioSqsSpec.scala
+++ b/zio-sqs/src/test/scala/zio/sqs/ZioSqsSpec.scala
@@ -65,7 +65,7 @@ object ZioSqsSpec extends ZIOSpecDefault {
 
   val gen: Gen[Sized, Chunk[String]] = Util.chunkOfStringsN(10)
 
-  def withFastClock: ZIO[Live, Nothing, Long] =
+  def withFastClock: ZIO[Live, Any, Long] =
     Live.withLive(TestClock.adjust(1.seconds))(_.repeat[Live, Long](Schedule.spaced(10.millis)))
 
   def sendAndGet(messages: Seq[String], settings: SqsStreamSettings): ZIO[Live with Sqs, Throwable, Chunk[Message.ReadOnly]] =

--- a/zio-sqs/src/test/scala/zio/sqs/producer/ProducerSpec.scala
+++ b/zio-sqs/src/test/scala/zio/sqs/producer/ProducerSpec.scala
@@ -628,7 +628,7 @@ object ProducerSpec extends ZIOSpecDefault {
   def queueResource(capacity: Int): ZIO[Scope, Throwable, Queue[SqsRequestEntry[String]]] =
     ZIO.acquireRelease(Queue.bounded[SqsRequestEntry[String]](capacity))(_.shutdown)
 
-  def withFastClock: ZIO[Live, Nothing, Long] =
+  def withFastClock: ZIO[Live, Any, Long] =
     Live.withLive(TestClock.adjust(1.seconds))(_.repeat[Live, Long](Schedule.spaced(10.millis)))
 
   /**
@@ -649,8 +649,7 @@ object ProducerSpec extends ZIOSpecDefault {
   }
 }
 
-class StubSqsService extends Sqs {
-  override lazy val api: SqsAsyncClient                                                                                                                      = ???
+case class StubSqsService(api: SqsAsyncClient = null) extends Sqs {
   override def getQueueAttributes(request: model.GetQueueAttributesRequest): IO[AwsError, GetQueueAttributesResponse.ReadOnly]                               = ???
   override def sendMessage(request: model.SendMessageRequest): IO[AwsError, SendMessageResponse.ReadOnly]                                                    = ???
   override def listQueues(request: model.ListQueuesRequest): ZStream[Any, AwsError, String]                                                                  = ???


### PR DESCRIPTION
author Ryan Stradling <ryanstradling@gmail.com> 1673316256 -0500 committer Ryan Stradling <ryanstradling@gmail.com> 1673454984 -0500

Fixes #632 but in a slightly different way than that ticket was leaning towards

### Approach
The major issue with Scala3 compilation and this code base are the tests and dependency on elasticMq which does not have a Scala3 version of its code (assuming that is due to the Akka dependency).  The one approach would be to update ElasticMq to do a cross-compile to Scala3 but to achieve that Akka would most likely need to be replaced with another http service.  This should probably be done but may take a while.

The other way to approach this is to use 2.13 libraries in Scala3 by using the library dependency sbt sugar of `cross CrossVersion.for3Use2_13`.

### Details
In the build.sbt file we are using a 2.13 `ElasticMq` library for tests only for Scala3.  I cannot guarantee that is a binary compatible scenario but things seem to run and given it is for tests am not too worried about it. Also in the build.sbt I removed a compiler plugin that did not seem to be used and there is no Scala3 equivalent for and moved the kind-projector compiler plugin only for 2.12 and 2.13.  I also updated the default build to scala 3.2.1 but am happy to change it back to 2.13

`case class StubSqsService(api: SqsAsyncClient = null)` was done because it used to have a lazy val api which in Scala3 cannot override a non-lazy val and seems to me like not a great thing.  I tried changing it to be a non-lazy val but had issues when running the tests. `withFastClock` interpreted in Scala 3 as `ZIO[Live, Any, Long]`.  I do not know the history of this difference but it seems to work on all versions just fine.  And again these are tests.