### PR TITLE
At least once delivery, batch deletions, message visibility extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ libraryDependencies += "dev.zio" %% "zio-sqs" % "0.6.5"
 
 ## Example
 
-In this example we produce a stream of events to the `MyQueue` and then consume them from that queue:
+In this example we produce a stream of events to the `MyQueue` and then consume them from that queue (at-most-once delivery semantics):
 
 ```scala
 import zio._
@@ -47,7 +47,10 @@ object ProducerConsumerExample extends ZIOAppDefault {
     _        <- ZIO.scoped(producer.flatMap(_.sendStream(stream).runDrain))
     _        <- SqsStream(
                   queueUrl,
-                  SqsStreamSettings(stopWhenQueueEmpty = true, waitTimeSeconds = Some(3))
+                  SqsStreamSettings.default
+                    .withAutoDelete(true)
+                    .withStopWhenQueueEmpty(true)
+                    .withWaitTimeSeconds(3)
                 ).foreach(msg => Console.printLine(msg.body))
   } yield ()
 
@@ -59,6 +62,8 @@ object ProducerConsumerExample extends ZIOAppDefault {
     )
 }
 ```
+
+Check out the examples folder in `zio-sqs/src/test/scala/examples` for additional examples that cover at-least-once and at-most-once delivery semantics.
 
 ## Documentation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ libraryDependencies += "dev.zio" %% "zio-sqs" % "@VERSION@"
 
 ## Example
 
-In this example we produce a stream of events to the `MyQueue` and then consume them from that queue:
+In this example we produce a stream of events to the `MyQueue` and then consume them from that queue (at-most-once delivery semantics):
 
 ```scala mdoc:compile-only
 import zio._
@@ -47,7 +47,10 @@ object ProducerConsumerExample extends ZIOAppDefault {
     _        <- ZIO.scoped(producer.flatMap(_.sendStream(stream).runDrain))
     _        <- SqsStream(
                   queueUrl,
-                  SqsStreamSettings(stopWhenQueueEmpty = true, waitTimeSeconds = Some(3))
+                  SqsStreamSettings.default
+                    .withAutoDelete(true)
+                    .withStopWhenQueueEmpty(true)
+                    .withWaitTimeSeconds(3)
                 ).foreach(msg => Console.printLine(msg.body))
   } yield ()
 
@@ -59,3 +62,5 @@ object ProducerConsumerExample extends ZIOAppDefault {
     )
 }
 ```
+
+Check out the examples folder in `zio-sqs/src/test/scala/examples` for additional examples that cover at-least-once and at-most-once delivery semantics.

--- a/zio-sqs/src/main/scala/zio/sqs/SqsStream.scala
+++ b/zio-sqs/src/main/scala/zio/sqs/SqsStream.scala
@@ -7,6 +7,7 @@ import zio.stream.ZStream
 import zio.aws.sqs.model.primitives.MessageAttributeName
 import zio.aws.core.AwsError
 import zio.aws.core.GenericAwsError
+import zio.stream.ZSink
 
 object SqsStream {
 
@@ -217,4 +218,16 @@ object SqsStream {
       .mapError(_.toThrowable)
       .runCollect
   }
+
+  /**
+   * A sink that deletes messages from the queue.
+   * If you use SqsStream with autoDelete = false in conjunction with this sink, you will get at-least-once semantics since
+   * the messages will be deleted after they are successfully processed.
+   *
+    * @param queueUrl
+   * @param maximumRetries
+   * @return
+   */
+  def deleteMessageBatchSink(queueUrl: String, maximumRetries: Int = 8): ZSink[Sqs, Throwable, Message.ReadOnly, Nothing, Unit] =
+    ZSink.foreachChunk[Sqs, Throwable, Message.ReadOnly](deleteMessageBatch(queueUrl, _, maximumRetries))
 }

--- a/zio-sqs/src/main/scala/zio/sqs/SqsStream.scala
+++ b/zio-sqs/src/main/scala/zio/sqs/SqsStream.scala
@@ -44,14 +44,19 @@ object SqsStream {
    * Consumes a batch of messages from the queue and deletes them after successful processing so users can focus on processing messages.
    * This will ignore autoDelete since messages are deleted only after successful processing.
    * This will also respect the stopWhenQueueEmpty setting.
+   * This will delete messages from the queue only after they have been successfully processed (process function).
    *
-   * @param queueUrl
-   * @param settings
+   * @param queueUrl is the SQS queue URL (example: https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue)
+   * @param settings are the settings for reading messages from the queue
+   * @param extensionSettings are the settings for the message lifetime extension
+   * @param consumerParallelism is the number of parallel consumers to run (default: 1)
+   * @param process is the function to process the messages
    */
   def consumeChunkAtLeastOnce(
     queueUrl: String,
     settings: SqsStreamSettings,
-    extensionSettings: SqsMessageLifetimeExtensionSettings
+    extensionSettings: SqsMessageLifetimeExtensionSettings,
+    consumerParallelism: Int = 1
   )(process: Chunk[Message.ReadOnly] => Task[Unit]): RIO[Sqs, Unit] = {
     val request = ReceiveMessageRequest(
       queueUrl = queueUrl,
@@ -89,7 +94,11 @@ object SqsStream {
           }
       }
 
-    pull.repeatWhile(_.nonEmpty || !settings.stopWhenQueueEmpty).unit
+    val consumerProcess = pull.repeatWhile(_.nonEmpty || !settings.stopWhenQueueEmpty).unit
+
+    ZIO.collectAllParDiscard(
+      List.fill(consumerParallelism)(consumerProcess)
+    )
   }
 
   /**

--- a/zio-sqs/src/main/scala/zio/sqs/SqsStream.scala
+++ b/zio-sqs/src/main/scala/zio/sqs/SqsStream.scala
@@ -10,18 +10,26 @@ import zio.aws.core.GenericAwsError
 
 object SqsStream {
 
+  /**
+   * Creates a consumer stream that pulls messages from the SQS queue.
+   * Note that if you set autoDelete to true, the message will be deleted from SQS before you can process the message (so if you fail to process the message, it will be deleted).
+   *
+   * @param queueUrl is the SQS queue URL (example: https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue)
+   * @param settings are the settings for reading messages from the queue
+   * @return a stream of messages from the queue
+   */
   def apply(
     queueUrl: String,
-    settings: SqsStreamSettings = SqsStreamSettings()
+    settings: SqsStreamSettings = SqsStreamSettings.default
   ): ZStream[Sqs, Throwable, Message.ReadOnly] = {
 
     val request = ReceiveMessageRequest(
       queueUrl = queueUrl,
-      attributeNames = Some(settings.attributeNames),
-      messageAttributeNames = Some(settings.messageAttributeNames.map(MessageAttributeName.apply(_))),
-      maxNumberOfMessages = Some(settings.maxNumberOfMessages),
-      visibilityTimeout = Some(settings.visibilityTimeout.getOrElse(30)),
-      waitTimeSeconds = Some(settings.waitTimeSeconds.getOrElse(20))
+      attributeNames = Option(settings.attributeNames).filter(_.nonEmpty),
+      messageAttributeNames = Option(settings.messageAttributeNames.map(MessageAttributeName.apply(_))),
+      maxNumberOfMessages = settings.maxNumberOfMessages,
+      visibilityTimeout = settings.visibilityTimeout,
+      waitTimeSeconds = settings.waitTimeSeconds
     )
 
     ZStream
@@ -60,9 +68,9 @@ object SqsStream {
   )(process: Chunk[Message.ReadOnly] => Task[Unit]): RIO[Sqs, Unit] = {
     val request = ReceiveMessageRequest(
       queueUrl = queueUrl,
-      attributeNames = Option(settings.attributeNames),
-      messageAttributeNames = Option(settings.messageAttributeNames.map(MessageAttributeName.apply(_))),
-      maxNumberOfMessages = Option(settings.maxNumberOfMessages),
+      attributeNames = Option(settings.attributeNames).filter(_.nonEmpty),
+      messageAttributeNames = Option(settings.messageAttributeNames.map(MessageAttributeName.apply(_))).filter(_.nonEmpty),
+      maxNumberOfMessages = settings.maxNumberOfMessages,
       visibilityTimeout = settings.visibilityTimeout,
       waitTimeSeconds = settings.waitTimeSeconds
     )

--- a/zio-sqs/src/main/scala/zio/sqs/SqsStream.scala
+++ b/zio-sqs/src/main/scala/zio/sqs/SqsStream.scala
@@ -44,7 +44,7 @@ object SqsStream {
       .flattenChunks
       .mapChunksZIO { messages =>
         // NOTE: At-most-once semantics (when autoDelete=true)
-        if (settings.autoDelete) deleteMessageBatch(queueUrl, messages)
+        if (settings.autoDelete) deleteMessageBatch(queueUrl, messages).as(messages)
         else Exit.succeed(messages)
       }
   }

--- a/zio-sqs/src/main/scala/zio/sqs/SqsStream.scala
+++ b/zio-sqs/src/main/scala/zio/sqs/SqsStream.scala
@@ -30,7 +30,7 @@ object SqsStream {
           .receiveMessage(request)
           .mapError(_.toThrowable)
       )
-      .map(_.messages.fold(Chunk.empty[Message.ReadOnly])(Chunk.from))
+      .map(_.messages.fold(Chunk.empty[Message.ReadOnly])(Chunk.fromIterable))
       .takeWhile(chunk => chunk.nonEmpty || !settings.stopWhenQueueEmpty)
       .flattenChunks
       .mapChunksZIO { messages =>
@@ -72,7 +72,7 @@ object SqsStream {
         response.messages
           .filter(_.nonEmpty)
           .fold[RIO[Sqs, Chunk[Message.ReadOnly]]](ifEmpty = Exit.succeed(Chunk.empty[Message.ReadOnly])) { underlying =>
-            val messages         = Chunk.from(underlying)
+            val messages         = Chunk.fromIterable(underlying)
             val extensionProcess =
               ZIO.sleep(extensionInitialDelay) *> ZIO
                 .when(extensionSettings.automaticExtension)(
@@ -136,15 +136,15 @@ object SqsStream {
 
             val errorMessage = ZIO.logWarning("Failed to change message visibility") @@ ZIOAspect.annotated("ids", failedIds.mkString("[", ", ", "]"))
             val retry        =
-              if (retriesRemaining > 0) go(Chunk.from(messagesToRetry), retriesRemaining - 1)
+              if (retriesRemaining > 0) go(Chunk.fromIterable(messagesToRetry), retriesRemaining - 1)
               else ZIO.fail(GenericAwsError(new RuntimeException("Failed to change message visibility after retrying")))
 
             errorMessage *> retry
-          } else Exit.succeed(Chunk.from(response.successful.map(each => idToMessageMap(each.id))))
+          } else Exit.succeed(Chunk.fromIterable(response.successful.map(each => idToMessageMap(each.id))))
         }
 
     ZStream
-      .from(Chunk.from(idToMessageMap))
+      .from(Chunk.fromIterable(idToMessageMap))
       .map { case (id, msg) => ChangeMessageVisibilityBatchRequestEntry(id, msg.receiptHandle.getOrElse(""), Option(seconds)) }
       .rechunk(10) // max batch size for changeMessageVisibilityBatch is 10
       .mapChunksZIO(go(_, maximumRetries))
@@ -182,18 +182,18 @@ object SqsStream {
             val messagesToRetry = failedIds.map(id => DeleteMessageBatchRequestEntry(id, idMessageMap(id).receiptHandle.getOrElse("")))
             val errorMessage    = ZIO.logWarning("Failed to delete messages, retrying") @@ ZIOAspect.annotated("ids", failedIds.mkString("[", ", ", "]"))
             val retry           =
-              if (retriesRemaining > 0) go(Chunk.from(messagesToRetry), retriesRemaining - 1)
+              if (retriesRemaining > 0) go(Chunk.fromIterable(messagesToRetry), retriesRemaining - 1)
               else ZIO.fail(GenericAwsError(new RuntimeException("Failed to delete messages after retrying")))
 
             errorMessage *> retry
           } else
             Exit.succeed(
-              Chunk.from(response.successful.map(each => idMessageMap(each.id)))
+              Chunk.fromIterable(response.successful.map(each => idMessageMap(each.id)))
             )
         }
 
     ZStream
-      .from(Chunk.from(idMessageMap))
+      .from(Chunk.fromIterable(idMessageMap))
       .map { case (id, msg) => DeleteMessageBatchRequestEntry(id, msg.receiptHandle.getOrElse("")) }
       .rechunk(10) // SQS Limit for deleteMessageBatch is 10
       .mapChunksZIO(go(_, maximumRetries))

--- a/zio-sqs/src/main/scala/zio/sqs/SqsStream.scala
+++ b/zio-sqs/src/main/scala/zio/sqs/SqsStream.scala
@@ -2,9 +2,11 @@ package zio.sqs
 
 import zio.aws.sqs._
 import zio.aws.sqs.model._
-import zio.{ RIO, ZIO }
+import zio.{ Chunk, Exit, RIO, Task, ZIO, ZIOAspect }
 import zio.stream.ZStream
 import zio.aws.sqs.model.primitives.MessageAttributeName
+import zio.aws.core.AwsError
+import zio.aws.core.GenericAwsError
 
 object SqsStream {
 
@@ -28,12 +30,174 @@ object SqsStream {
           .receiveMessage(request)
           .mapError(_.toThrowable)
       )
-      .map(_.messages.getOrElse(List.empty))
-      .takeWhile(_.nonEmpty || !settings.stopWhenQueueEmpty)
-      .mapConcat(identity)
-      .mapZIO(msg => ZIO.when(settings.autoDelete)(deleteMessage(queueUrl, msg)).as(msg))
+      .map(_.messages.fold(Chunk.empty[Message.ReadOnly])(Chunk.from))
+      .takeWhile(chunk => chunk.nonEmpty || !settings.stopWhenQueueEmpty)
+      .flattenChunks
+      .mapChunksZIO { messages =>
+        // NOTE: At-most-once semantics (when autoDelete=true)
+        if (settings.autoDelete) deleteMessageBatch(queueUrl, messages)
+        else Exit.succeed(messages)
+      }
+  }
+
+  /**
+   * Consumes a batch of messages from the queue and deletes them after successful processing so users can focus on processing messages.
+   * This will ignore autoDelete since messages are deleted only after successful processing.
+   * This will also respect the stopWhenQueueEmpty setting.
+   *
+   * @param queueUrl
+   * @param settings
+   */
+  def consumeChunkAtLeastOnce(
+    queueUrl: String,
+    settings: SqsStreamSettings,
+    extensionSettings: SqsMessageLifetimeExtensionSettings
+  )(process: Chunk[Message.ReadOnly] => Task[Unit]): RIO[Sqs, Unit] = {
+    val request = ReceiveMessageRequest(
+      queueUrl = queueUrl,
+      attributeNames = Option(settings.attributeNames),
+      messageAttributeNames = Option(settings.messageAttributeNames.map(MessageAttributeName.apply(_))),
+      maxNumberOfMessages = Option(settings.maxNumberOfMessages),
+      visibilityTimeout = settings.visibilityTimeout,
+      waitTimeSeconds = settings.waitTimeSeconds
+    )
+
+    val extensionSchedule     = extensionSettings.schedule(settings)
+    val extensionInitialDelay = extensionSettings.initialDelay(settings)
+
+    val pull: RIO[Sqs, Chunk[Message.ReadOnly]] = zio.aws.sqs.Sqs
+      .receiveMessage(request)
+      .mapError(_.toThrowable)
+      .flatMap { response =>
+        response.messages
+          .filter(_.nonEmpty)
+          .fold[RIO[Sqs, Chunk[Message.ReadOnly]]](ifEmpty = Exit.succeed(Chunk.empty[Message.ReadOnly])) { underlying =>
+            val messages         = Chunk.from(underlying)
+            val extensionProcess =
+              ZIO.sleep(extensionInitialDelay) *> ZIO
+                .when(extensionSettings.automaticExtension)(
+                  extendMessageLifetimeBatch(queueUrl, messages, extensionSettings.maximumRetries).ignoreLogged
+                )
+                .repeat(extensionSchedule)
+
+            // Note: Avoided using race in case the user supplies a finite extension schedule
+            for {
+              extensionFiber <- extensionProcess.fork
+              _              <- process(messages).onExit(_ => extensionFiber.interrupt)
+              result         <- deleteMessageBatch(queueUrl, messages)
+            } yield result
+          }
+      }
+
+    pull.repeatWhile(_.nonEmpty || !settings.stopWhenQueueEmpty).unit
+  }
+
+  /**
+   * Extends the visibility timeout of a message to the specified number of seconds.
+   * This is useful when you need to process a message and the time it takes to process it is longer than the visibility timeout.
+   *
+   * @param queueUrl
+   * @param message
+   * @param seconds
+   */
+  def extendMessageLifetime(queueUrl: String, message: Message.ReadOnly, seconds: Int): RIO[Sqs, Unit] =
+    zio.aws.sqs.Sqs
+      .changeMessageVisibility(
+        ChangeMessageVisibilityRequest(
+          queueUrl = queueUrl,
+          receiptHandle = message.receiptHandle.getOrElse(""),
+          visibilityTimeout = seconds
+        )
+      )
+      .mapError(_.toThrowable)
+
+  def extendMessageLifetimeBatch(
+    queueUrl: String,
+    messages: Chunk[Message.ReadOnly],
+    seconds: Int,
+    maximumRetries: Int = 8
+  ): RIO[Sqs, Chunk[Message.ReadOnly]] = {
+    val idToMessageMap = messages.zipWithIndex.map { case (msg, id) => id.toString -> msg }.toMap
+
+    def go(entries: Chunk[ChangeMessageVisibilityBatchRequestEntry], retriesRemaining: Int): ZIO[Sqs, AwsError, Chunk[Message.ReadOnly]] =
+      zio.aws.sqs.Sqs
+        .changeMessageVisibilityBatch(
+          ChangeMessageVisibilityBatchRequest(
+            queueUrl = queueUrl,
+            entries = entries
+          )
+        )
+        .flatMap { response =>
+          if (response.failed.nonEmpty) {
+            // Since we only get the ids back of messages that failed, we use the map to obtain the original message to retry
+            val failedIds       = response.failed.map(_.id)
+            val messagesToRetry =
+              failedIds.map(id => ChangeMessageVisibilityBatchRequestEntry(id, idToMessageMap(id).receiptHandle.getOrElse(""), Option(seconds)))
+
+            val errorMessage = ZIO.logWarning("Failed to change message visibility") @@ ZIOAspect.annotated("ids", failedIds.mkString("[", ", ", "]"))
+            val retry        =
+              if (retriesRemaining > 0) go(Chunk.from(messagesToRetry), retriesRemaining - 1)
+              else ZIO.fail(GenericAwsError(new RuntimeException("Failed to change message visibility after retrying")))
+
+            errorMessage *> retry
+          } else Exit.succeed(Chunk.from(response.successful.map(each => idToMessageMap(each.id))))
+        }
+
+    ZStream
+      .from(Chunk.from(idToMessageMap))
+      .map { case (id, msg) => ChangeMessageVisibilityBatchRequestEntry(id, msg.receiptHandle.getOrElse(""), Option(seconds)) }
+      .rechunk(10) // max batch size for changeMessageVisibilityBatch is 10
+      .mapChunksZIO(go(_, maximumRetries))
+      .mapError(_.toThrowable)
+      .runCollect
   }
 
   def deleteMessage(queueUrl: String, msg: Message.ReadOnly): RIO[Sqs, Unit] =
     zio.aws.sqs.Sqs.deleteMessage(DeleteMessageRequest(queueUrl, msg.receiptHandle.getOrElse(""))).mapError(_.toThrowable)
+
+  /**
+   * Deletes a batch of messages from the queue. This method retries deleting messages that fail and internally uses the message IDs to retry.
+   * It also chunks up the messages into batches of 10 before deleting them to avoid hitting the SQS limit of 10 messages per deleteMessageBatch call.
+   *
+   * @param queueUrl
+   * @param msgs
+   */
+  def deleteMessageBatch(queueUrl: String, msgs: Chunk[Message.ReadOnly], maximumRetries: Int = 8): RIO[Sqs, Chunk[Message.ReadOnly]] = {
+    // We need to keep track of the original message IDs to retry later
+    // IDs are unique per batch, we use the index of the messages in the batch to generate a unique ID for each message
+    val idMessageMap = msgs.zipWithIndex.map { case (msg, id) => id.toString -> msg }.toMap
+
+    def go(entries: Chunk[DeleteMessageBatchRequestEntry], retriesRemaining: Int): ZIO[Sqs, AwsError, Chunk[Message.ReadOnly]] =
+      zio.aws.sqs.Sqs
+        .deleteMessageBatch(
+          DeleteMessageBatchRequest(
+            queueUrl = queueUrl,
+            entries = entries
+          )
+        )
+        .flatMap { response =>
+          if (response.failed.nonEmpty) {
+            // Since we only get the ids back of messages that failed, we use the map to obtain the original message to retry
+            val failedIds       = response.failed.map(_.id)
+            val messagesToRetry = failedIds.map(id => DeleteMessageBatchRequestEntry(id, idMessageMap(id).receiptHandle.getOrElse("")))
+            val errorMessage    = ZIO.logWarning("Failed to delete messages, retrying") @@ ZIOAspect.annotated("ids", failedIds.mkString("[", ", ", "]"))
+            val retry           =
+              if (retriesRemaining > 0) go(Chunk.from(messagesToRetry), retriesRemaining - 1)
+              else ZIO.fail(GenericAwsError(new RuntimeException("Failed to delete messages after retrying")))
+
+            errorMessage *> retry
+          } else
+            Exit.succeed(
+              Chunk.from(response.successful.map(each => idMessageMap(each.id)))
+            )
+        }
+
+    ZStream
+      .from(Chunk.from(idMessageMap))
+      .map { case (id, msg) => DeleteMessageBatchRequestEntry(id, msg.receiptHandle.getOrElse("")) }
+      .rechunk(10) // SQS Limit for deleteMessageBatch is 10
+      .mapChunksZIO(go(_, maximumRetries))
+      .mapError(_.toThrowable)
+      .runCollect
+  }
 }

--- a/zio-sqs/src/main/scala/zio/sqs/SqsStreamSettings.scala
+++ b/zio-sqs/src/main/scala/zio/sqs/SqsStreamSettings.scala
@@ -1,6 +1,7 @@
 package zio.sqs
 
 import zio.aws.sqs.model._
+import zio._
 
 case class SqsStreamSettings(
   attributeNames: List[QueueAttributeName] = Nil,
@@ -11,3 +12,35 @@ case class SqsStreamSettings(
   autoDelete: Boolean = true,
   stopWhenQueueEmpty: Boolean = false
 )
+
+final case class SqsMessageLifetimeExtensionSettings(
+  automaticExtension: Boolean,
+  maximumRetries: Int,
+  overrideInitialDelay: Option[Duration],
+  overrideRepeatSchedule: Option[Schedule[Any, Any, Any]]
+)                                          {
+  def schedule(settings: SqsStreamSettings): Schedule[Any, Any, Any] =
+    overrideRepeatSchedule.getOrElse(
+      Schedule.spaced(
+        settings.visibilityTimeout
+          .map(_ / 2)
+          .getOrElse(15)
+          .seconds
+      )
+    )
+
+  def initialDelay(settings: SqsStreamSettings): Duration =
+    overrideInitialDelay.getOrElse(
+      settings.visibilityTimeout
+        .map(secs => (secs / 2).seconds)
+        .getOrElse(15.seconds)
+    )
+}
+object SqsMessageLifetimeExtensionSettings {
+  val default: SqsMessageLifetimeExtensionSettings = SqsMessageLifetimeExtensionSettings(
+    automaticExtension = true,
+    maximumRetries = 16,
+    overrideInitialDelay = None,
+    overrideRepeatSchedule = None
+  )
+}

--- a/zio-sqs/src/main/scala/zio/sqs/SqsStreamSettings.scala
+++ b/zio-sqs/src/main/scala/zio/sqs/SqsStreamSettings.scala
@@ -3,15 +3,53 @@ package zio.sqs
 import zio.aws.sqs.model._
 import zio._
 
-case class SqsStreamSettings(
-  attributeNames: List[QueueAttributeName] = Nil,
-  maxNumberOfMessages: Int = 1,
-  messageAttributeNames: List[String] = Nil,
-  visibilityTimeout: Option[Int] = Some(30),
-  waitTimeSeconds: Option[Int] = Some(20),
-  autoDelete: Boolean = true,
-  stopWhenQueueEmpty: Boolean = false
-)
+final case class SqsStreamSettings(
+  attributeNames: List[QueueAttributeName],
+  maxNumberOfMessages: Option[Int],
+  messageAttributeNames: List[String],
+  visibilityTimeout: Option[Int],
+  waitTimeSeconds: Option[Int],
+  autoDelete: Boolean,
+  stopWhenQueueEmpty: Boolean
+)                        {
+  def withAttributeName(attributeName: QueueAttributeName): SqsStreamSettings =
+    copy(attributeNames = attributeName :: attributeNames)
+
+  def withAttributeNames(attributeNames: List[QueueAttributeName]): SqsStreamSettings =
+    copy(attributeNames = attributeNames)
+
+  def withMaxNumberOfMessages(maxNumberOfMessages: Int): SqsStreamSettings =
+    copy(maxNumberOfMessages = Some(maxNumberOfMessages))
+
+  def withMessageAttributeName(name: String): SqsStreamSettings =
+    copy(messageAttributeNames = name :: messageAttributeNames)
+
+  def withMessageAttributeNames(names: List[String]): SqsStreamSettings =
+    copy(messageAttributeNames = messageAttributeNames ::: names)
+
+  def withVisibilityTimeout(seconds: Int): SqsStreamSettings =
+    copy(visibilityTimeout = Some(seconds))
+
+  def withWaitTimeSeconds(seconds: Int): SqsStreamSettings =
+    copy(waitTimeSeconds = Some(seconds))
+
+  def withAutoDelete(autoDelete: Boolean): SqsStreamSettings =
+    copy(autoDelete = autoDelete)
+
+  def withStopWhenQueueEmpty(stopWhenQueueEmpty: Boolean): SqsStreamSettings =
+    copy(stopWhenQueueEmpty = stopWhenQueueEmpty)
+}
+object SqsStreamSettings {
+  val default = SqsStreamSettings(
+    attributeNames = Nil,
+    maxNumberOfMessages = None,
+    messageAttributeNames = Nil,
+    visibilityTimeout = None,
+    waitTimeSeconds = None,
+    autoDelete = false,
+    stopWhenQueueEmpty = false
+  )
+}
 
 final case class SqsMessageLifetimeExtensionSettings(
   automaticExtension: Boolean,
@@ -19,6 +57,15 @@ final case class SqsMessageLifetimeExtensionSettings(
   overrideInitialDelay: Option[Duration],
   overrideRepeatSchedule: Option[Schedule[Any, Any, Any]]
 )                                          {
+  def withAutomaticExtension(automaticExtension: Boolean): SqsMessageLifetimeExtensionSettings =
+    copy(automaticExtension = automaticExtension)
+
+  def withMaximumRetries(maximumRetries: Int): SqsMessageLifetimeExtensionSettings =
+    copy(maximumRetries = maximumRetries)
+
+  def withOverrideInitialDelay(overrideInitialDelay: Duration): SqsMessageLifetimeExtensionSettings =
+    copy(overrideInitialDelay = Some(overrideInitialDelay))
+
   def schedule(settings: SqsStreamSettings): Schedule[Any, Any, Any] =
     overrideRepeatSchedule.getOrElse(
       Schedule.spaced(

--- a/zio-sqs/src/main/scala/zio/sqs/producer/Producer.scala
+++ b/zio-sqs/src/main/scala/zio/sqs/producer/Producer.scala
@@ -97,16 +97,16 @@ object Producer {
    * @tparam T type of the event to publish
    * @return managed producer for publishing events.
    */
-  def make[R, T](
+  def make[T](
     queueUrl: String,
     serializer: Serializer[T],
     settings: ProducerSettings = ProducerSettings()
-  ): ZIO[R with Sqs with Scope, Throwable, Producer[T]] = {
+  ): ZIO[Sqs & Scope, Throwable, Producer[T]] = {
     val eventQueueSize = nextPower2(settings.batchSize * settings.parallelism)
     for {
       eventQueue <- ZIO.acquireRelease(Queue.bounded[SqsRequestEntry[T]](eventQueueSize))(_.shutdown)
       failQueue  <- ZIO.acquireRelease(Queue.bounded[SqsRequestEntry[T]](eventQueueSize))(_.shutdown)
-      reqRunner   = runSendMessageBatchRequest[R, T](failQueue, settings.retryDelay, settings.retryMaxCount) _
+      reqRunner   = runSendMessageBatchRequest[T](failQueue, settings.retryDelay, settings.retryMaxCount) _
       reqBuilder  = buildSendMessageBatchRequest(queueUrl, serializer) _
       stream      = ZStream.fromQueue(failQueue)
                       .merge(ZStream.fromQueue(eventQueue))
@@ -116,7 +116,7 @@ object Producer {
                       )
                       .map(chunks => reqBuilder(chunks.toList))
                       .mapZIOParUnordered(settings.parallelism)(reqRunner)
-      _          <- stream.runDrain.forkDaemon
+      _          <- stream.runDrain.forkScoped
     } yield new DefaultProducer[T](eventQueue, settings)
   }
 
@@ -192,13 +192,12 @@ object Producer {
    * @param retryDelay delay to wait inserting events to the failedQueue.
    * @param retryMaxCount max allowed number of retries per event.
    * @param req batch-request to send to SQS.
-   * @tparam R zio environment.
    * @tparam T type of the event to publish.
    * @return result of the operation.
    */
-  private[sqs] def runSendMessageBatchRequest[R, T](failedQueue: Queue[SqsRequestEntry[T]], retryDelay: Duration, retryMaxCount: Int)(
+  private[sqs] def runSendMessageBatchRequest[T](failedQueue: Queue[SqsRequestEntry[T]], retryDelay: Duration, retryMaxCount: Int)(
     req: SqsRequest[T]
-  ): RIO[R with Sqs, Unit] =
+  ): RIO[Sqs, Unit] =
     zio.aws.sqs.Sqs
       .sendMessageBatch(req.inner)
       .mapError(_.toThrowable)

--- a/zio-sqs/src/test/scala/examples/AtLeastOnceExample.scala
+++ b/zio-sqs/src/test/scala/examples/AtLeastOnceExample.scala
@@ -12,11 +12,12 @@ import zio.sqs._
 import zio.aws.sqs.model.Message
 
 object AtLeastOnceExample extends ZIOAppDefault {
+  val queueUrl = "https://sqs.us-east-1.amazonaws.com/00000/calq.fifo"
 
   val producerLayer: RLayer[Sqs, Producer[String]] =
     ZLayer.scoped(
       Producer.make(
-        queueUrl = "https://sqs.us-east-1.amazonaws.com/000/calq.fifo",
+        queueUrl = queueUrl,
         serializer = Serializer.serializeString,
         settings = ProducerSettings(parallelism = 1)
       )
@@ -25,7 +26,7 @@ object AtLeastOnceExample extends ZIOAppDefault {
   val producerExample =
     ZIO.serviceWithZIO[Producer[String]] { producer =>
       producer.produceBatch(
-        (200 to 300).map(i =>
+        (0 to 200).map(i =>
           ProducerEvent(
             data = s"Message $i",
             attributes = Map.empty,
@@ -41,17 +42,23 @@ object AtLeastOnceExample extends ZIOAppDefault {
 
   val consumerExample =
     SqsStream.consumeChunkAtLeastOnce(
-      queueUrl = "https://sqs.us-east-1.amazonaws.com/000/calq.fifo",
-      settings = SqsStreamSettings.default.copy(
-        maxNumberOfMessages = Option(10),
-        visibilityTimeout = Some(5),
-        waitTimeSeconds = Some(20)
-      ),
+      queueUrl = queueUrl,
+      settings = SqsStreamSettings.default
+        .withMaxNumberOfMessages(10)
+        .withVisibilityTimeout(5)
+        .withWaitTimeSeconds(20),
       extensionSettings = SqsMessageLifetimeExtensionSettings.default,
       consumerParallelism = 10
     ) { (messages: Chunk[Message.ReadOnly]) =>
       ZIO.debug(messages.map(_.body.getOrElse(""))) *> ZIO.sleep(14.seconds)
     }
+
+  val consumerStreamExample =
+    SqsStream(
+      queueUrl = queueUrl,
+      settings = SqsStreamSettings.default.withAutoDelete(false)
+    ).tap(message => ZIO.debug(message.body.getOrElse("")))
+      .run(SqsStream.deleteMessageBatchSink(queueUrl))
 
   override val run: ZIO[Environment with ZIOAppArgs with Scope, Any, Any] =
     (producerExample *> consumerExample)

--- a/zio-sqs/src/test/scala/examples/AtLeastOnceExample.scala
+++ b/zio-sqs/src/test/scala/examples/AtLeastOnceExample.scala
@@ -1,0 +1,75 @@
+package examples
+
+import zio._
+import zio.sqs.producer._
+import zio.sqs.serialization.Serializer
+import zio.aws.netty.NettyHttpClient
+import zio.aws.sqs.Sqs
+import zio.aws.core.config._
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.auth.credentials._
+import zio.sqs._
+import zio.aws.sqs.model.Message
+
+object AtLeastOnceExample extends ZIOAppDefault {
+
+  val producerLayer: RLayer[Sqs, Producer[String]] =
+    ZLayer.scoped(
+      Producer.make(
+        queueUrl = "https://sqs.us-east-1.amazonaws.com/000/calq.fifo",
+        serializer = Serializer.serializeString,
+        settings = ProducerSettings(parallelism = 1)
+      )
+    )
+
+  val producerExample =
+    ZIO.serviceWithZIO[Producer[String]] { producer =>
+      producer.produceBatch(
+        (200 to 300).map(i =>
+          ProducerEvent(
+            data = s"Message $i",
+            attributes = Map.empty,
+            groupId = Some(
+              if (i % 2 == 0) "even"
+              else "odd"
+            ),
+            deduplicationId = None
+          )
+        )
+      )
+    }
+
+  val consumerExample =
+    SqsStream.consumeChunkAtLeastOnce(
+      queueUrl = "https://sqs.us-east-1.amazonaws.com/000/calq.fifo",
+      settings = SqsStreamSettings.default.copy(
+        maxNumberOfMessages = Option(10),
+        visibilityTimeout = Some(5),
+        waitTimeSeconds = Some(20)
+      ),
+      extensionSettings = SqsMessageLifetimeExtensionSettings.default,
+      consumerParallelism = 10
+    ) { (messages: Chunk[Message.ReadOnly]) =>
+      ZIO.debug(messages.map(_.body.getOrElse(""))) *> ZIO.sleep(14.seconds)
+    }
+
+  override val run: ZIO[Environment with ZIOAppArgs with Scope, Any, Any] =
+    (producerExample *> consumerExample)
+      .provide(
+        producerLayer,
+        Sqs.live,
+        NettyHttpClient.default,
+        AwsConfig.configured(),
+        ZLayer.succeed(
+          CommonAwsConfig(
+            region = Option(Region.US_EAST_1),
+            credentialsProvider = StaticCredentialsProvider.create(
+              AwsBasicCredentials.create("key", "secret")
+            ),
+            endpointOverride = None,
+            commonClientConfig = None
+          )
+        )
+      )
+
+}

--- a/zio-sqs/src/test/scala/examples/AtMostOnceExample.scala
+++ b/zio-sqs/src/test/scala/examples/AtMostOnceExample.scala
@@ -9,7 +9,7 @@ import zio.sqs.serialization.Serializer
 import zio.sqs.{ SqsStream, SqsStreamSettings, Utils }
 import zio._
 
-object TestApp extends zio.ZIOAppDefault {
+object AtMostOnceExample extends zio.ZIOAppDefault {
   val queueName = "TestQueue"
 
   val client: ZLayer[Any, Throwable, Sqs] =
@@ -36,7 +36,7 @@ object TestApp extends zio.ZIOAppDefault {
                 }
     _        <- SqsStream(
                   queueUrl,
-                  SqsStreamSettings.default.withStopWhenQueueEmpty(true).withWaitTimeSeconds(3)
+                  SqsStreamSettings.default.withStopWhenQueueEmpty(true).withWaitTimeSeconds(3).withAutoDelete(true)
                 ).foreach(msg => ZIO.succeed(println(msg.body)))
   } yield ()
 

--- a/zio-sqs/src/test/scala/examples/TestApp.scala
+++ b/zio-sqs/src/test/scala/examples/TestApp.scala
@@ -36,7 +36,7 @@ object TestApp extends zio.ZIOAppDefault {
                 }
     _        <- SqsStream(
                   queueUrl,
-                  SqsStreamSettings(stopWhenQueueEmpty = true, waitTimeSeconds = Some(3))
+                  SqsStreamSettings.default.withStopWhenQueueEmpty(true).withWaitTimeSeconds(3)
                 ).foreach(msg => ZIO.succeed(println(msg.body)))
   } yield ()
 

--- a/zio-sqs/src/test/scala/zio/sqs/ZioSqsSpec.scala
+++ b/zio-sqs/src/test/scala/zio/sqs/ZioSqsSpec.scala
@@ -17,7 +17,7 @@ object ZioSqsSpec extends ZIOSpecDefault {
   override def spec =
     suite("ZioSqsSpec")(
       test("send messages") {
-        val settings: SqsStreamSettings = SqsStreamSettings(stopWhenQueueEmpty = true)
+        val settings: SqsStreamSettings = SqsStreamSettings.default.withStopWhenQueueEmpty(true)
 
         for {
           messages <- gen.runHead.someOrFailException
@@ -27,7 +27,10 @@ object ZioSqsSpec extends ZIOSpecDefault {
       },
       test("delete messages manually") {
         val settings: SqsStreamSettings =
-          SqsStreamSettings(stopWhenQueueEmpty = true, autoDelete = false, waitTimeSeconds = Some(1))
+          SqsStreamSettings.default
+            .withStopWhenQueueEmpty(true)
+            .withAutoDelete(false)
+            .withWaitTimeSeconds(1)
 
         for {
           messages <- gen.runHead.someOrFailException
@@ -43,7 +46,7 @@ object ZioSqsSpec extends ZIOSpecDefault {
         } yield assert(list)(isEmpty)
       },
       test("delete messages automatically") {
-        val settings: SqsStreamSettings = SqsStreamSettings(stopWhenQueueEmpty = true, waitTimeSeconds = Some(1))
+        val settings: SqsStreamSettings = SqsStreamSettings.default.withStopWhenQueueEmpty(true).withWaitTimeSeconds(1)
 
         for {
           messages <- gen.runHead.someOrFailException
@@ -58,12 +61,11 @@ object ZioSqsSpec extends ZIOSpecDefault {
         } yield assert(list)(isEmpty)
       },
       test("consumeChunkAtLeastOnce will not delete messages if there is an error encountered when processing") {
-        val settings = SqsStreamSettings(
-          stopWhenQueueEmpty = true,
-          waitTimeSeconds = Some(1),
-          visibilityTimeout = Some(2),
-          maxNumberOfMessages = 10000
-        )
+        val settings = SqsStreamSettings.default
+          .withStopWhenQueueEmpty(true)
+          .withWaitTimeSeconds(1)
+          .withVisibilityTimeout(2)
+          .withMaxNumberOfMessages(10000)
 
         val program =
           for {
@@ -87,12 +89,11 @@ object ZioSqsSpec extends ZIOSpecDefault {
         ZIO.scoped(program)
       } @@ TestAspect.withLiveClock,
       test("consumeChunkAtLeastOnce will automatically extend message lifetime and delete messages after successful processing") {
-        val settings = SqsStreamSettings(
-          stopWhenQueueEmpty = true,
-          waitTimeSeconds = Some(1),
-          visibilityTimeout = Some(2),
-          maxNumberOfMessages = 10000
-        )
+        val settings = SqsStreamSettings.default
+          .withStopWhenQueueEmpty(true)
+          .withWaitTimeSeconds(1)
+          .withVisibilityTimeout(2)
+          .withMaxNumberOfMessages(10000)
 
         val program = for {
           _              <- serverResource

--- a/zio-sqs/src/test/scala/zio/sqs/ZioSqsSpec.scala
+++ b/zio-sqs/src/test/scala/zio/sqs/ZioSqsSpec.scala
@@ -10,6 +10,7 @@ import zio.test.Assertion._
 import zio.test._
 import zio.test.{ Live, TestEnvironment }
 import testing._
+import zio.sqs.SqsStream.consumeChunkAtLeastOnce
 
 object ZioSqsSpec extends ZIOSpecDefault {
 
@@ -55,7 +56,63 @@ object ZioSqsSpec extends ZIOSpecDefault {
                         }
                       }
         } yield assert(list)(isEmpty)
-      }
+      },
+      test("consumeChunkAtLeastOnce will not delete messages if there is an error encountered when processing") {
+        val settings = SqsStreamSettings(
+          stopWhenQueueEmpty = true,
+          waitTimeSeconds = Some(1),
+          visibilityTimeout = Some(2),
+          maxNumberOfMessages = 10_000
+        )
+
+        val program =
+          for {
+            _              <- serverResource
+            messages       <- gen.runHead.someOrFailException
+            _              <- Utils.createQueue(queueName)
+            queueUrl       <- Utils.getQueueUrl(queueName)
+            producer        = Producer.make(queueUrl, Serializer.serializeString)
+            _              <- ZIO.scoped(producer.flatMap(p => ZIO.foreach(messages)(msg => p.produce(ProducerEvent(msg)))))
+            messagePromise <- Promise.make[Nothing, Chunk[Message.ReadOnly]]
+            _              <- consumeChunkAtLeastOnce(queueUrl, settings, SqsMessageLifetimeExtensionSettings.default) { _ =>
+                                ZIO.fail(new RuntimeException("Purposefully KABOOM"))
+                              }.exit
+            // messages won't reappear immediately due to the visibility timeout so we repeatedly poll until they are back
+            _              <- consumeChunkAtLeastOnce(queueUrl, settings, SqsMessageLifetimeExtensionSettings.default) { msgs =>
+                                messagePromise.succeed(msgs).unit
+                              }.repeatWhileZIO(_ => messagePromise.poll.map(_.isEmpty))
+            actual         <- messagePromise.await
+            actualMessages  = actual.map(_.body.getOrElse(""))
+          } yield assert(actualMessages)(hasSameElements(messages))
+        ZIO.scoped(program)
+      } @@ TestAspect.withLiveClock,
+      test("consumeChunkAtLeastOnce will automatically extend message lifetime and delete messages after successful processing") {
+        val settings = SqsStreamSettings(
+          stopWhenQueueEmpty = true,
+          waitTimeSeconds = Some(1),
+          visibilityTimeout = Some(2),
+          maxNumberOfMessages = 10_000
+        )
+
+        val program = for {
+          _              <- serverResource
+          messages       <- gen.runHead.someOrFailException
+          _              <- Utils.createQueue(queueName)
+          queueUrl       <- Utils.getQueueUrl(queueName)
+          producer        = Producer.make(queueUrl, Serializer.serializeString)
+          _              <- ZIO.scoped(producer.flatMap(p => ZIO.foreach(messages)(msg => p.produce(ProducerEvent(msg)))))
+          messagePromise <- Promise.make[Nothing, Chunk[Message.ReadOnly]]
+          _              <- consumeChunkAtLeastOnce(queueUrl, settings, SqsMessageLifetimeExtensionSettings.default) { msgs =>
+                              ZIO.sleep(2500.millis) *> messagePromise.succeed(msgs).unit
+                            }
+          _              <- consumeChunkAtLeastOnce(queueUrl, settings, SqsMessageLifetimeExtensionSettings.default) { msgs =>
+                              ZIO.fail(new RuntimeException(s"Should not be called because the previous call should have processed all messages ($msgs)"))
+                            }
+          actual         <- messagePromise.await
+        } yield assert(actual.map(_.body.getOrElse("")))(equalTo(messages))
+
+        ZIO.scoped(program)
+      } @@ TestAspect.withLiveClock
     ).provideSomeLayerShared[TestEnvironment]((zio.aws.netty.NettyHttpClient.default >>> zio.aws.core.config.AwsConfig.default >>> clientResource).orDie)
 
   override def aspects: Chunk[TestAspect[Nothing, TestEnvironment, Nothing, Any]] =

--- a/zio-sqs/src/test/scala/zio/sqs/ZioSqsSpec.scala
+++ b/zio-sqs/src/test/scala/zio/sqs/ZioSqsSpec.scala
@@ -62,7 +62,7 @@ object ZioSqsSpec extends ZIOSpecDefault {
           stopWhenQueueEmpty = true,
           waitTimeSeconds = Some(1),
           visibilityTimeout = Some(2),
-          maxNumberOfMessages = 10_000
+          maxNumberOfMessages = 10000
         )
 
         val program =
@@ -91,7 +91,7 @@ object ZioSqsSpec extends ZIOSpecDefault {
           stopWhenQueueEmpty = true,
           waitTimeSeconds = Some(1),
           visibilityTimeout = Some(2),
-          maxNumberOfMessages = 10_000
+          maxNumberOfMessages = 10000
         )
 
         val program = for {

--- a/zio-sqs/src/test/scala/zio/sqs/producer/ProducerSpec.scala
+++ b/zio-sqs/src/test/scala/zio/sqs/producer/ProducerSpec.scala
@@ -20,7 +20,9 @@ import zio.sqs.testing._
 import scala.language.implicitConversions
 
 object ProducerSpec extends ZIOSpecDefault {
-  implicit def batchResultErrorEntryAsReadOnly(e: BatchResultErrorEntry): BatchResultErrorEntry.ReadOnly          = BatchResultErrorEntry.wrap(e.buildAwsValue())
+  implicit def batchResultErrorEntryAsReadOnly(e: BatchResultErrorEntry): BatchResultErrorEntry.ReadOnly =
+    BatchResultErrorEntry.wrap(e.buildAwsValue())
+
   implicit def sendMessageBatchResponseAsReadOnly(e: SendMessageBatchResponse): SendMessageBatchResponse.ReadOnly =
     SendMessageBatchResponse.wrap(e.buildAwsValue())
 
@@ -601,7 +603,7 @@ object ProducerSpec extends ZIOSpecDefault {
           _               <- withFastClock.fork
           scope           <- Scope.make
           producerPromise <- Producer
-                               .make[Any, String](queueUrl, Serializer.serializeString, settings)
+                               .make[String](queueUrl, Serializer.serializeString, settings)
                                .provide(client, ZLayer.succeed(scope))
                                .fork
 


### PR DESCRIPTION
## Changes

- Implement a high level at-least-once-delivery API (`consumeChunkAtLeastOnce`) that allows users to focus on processing messages and once successful, deleting the messages from the queue. 
  - In addition, if processing takes long, automatic message extension requests are sent out to SQS (configurable) so other consumers won't see the message until processing finishes
  - Inspiration for this API was taken from FS2 Kafka's `consumeChunk` API
- Improve SqsStream so deletes are batched reducing API calls (when `autoDelete=true`)
  - Improve performance by preserving internal chunking structure (replaced mapZIO)
- Implement batch deletes
- Implement message visibility extension (batch/single)
- Tests for `consumeChunkAtLeastOnce` that ensure failed processing causes re-delivery and the automatic extension process is functioning correctly
- Implement ZSink `deleteMessageBatchSink` which can be used with `SqsStream` with `autoDelete=false` to provide at-least-once delivery semantics so users can process their message and then delete it. 

Addresses https://github.com/zio/zio-sqs/issues/587 and https://github.com/zio/zio-sqs/issues/259 including taking care of retries during batched deletes

**Note:** There are breaking changes to adhere to the AWS defaults in SqsSettings as well as removing an unneeded type parameter in `Producer.make`

---
### AWS SQS testing (**Note:** account removed):

```scala
  val producerLayer: RLayer[Sqs, Producer[String]] =
    ZLayer.scoped(
      Producer.make(
        queueUrl = "https://sqs.us-east-1.amazonaws.com/000/calqstandard",
        serializer = Serializer.serializeString,
        settings = ProducerSettings(parallelism = 1)
      )
    )

  val producerExample =
    ZIO.serviceWithZIO[Producer[String]] { producer =>
      producer.produceBatch(
        (1 to 1_000).map(i => ProducerEvent(s"Message $i"))
      )
    }

  val consumerExample =
    SqsStream.consumeChunkAtLeastOnce(
      queueUrl = "https://sqs.us-east-1.amazonaws.com/000/calqstandard",
      settings = SqsStreamSettings(
        maxNumberOfMessages = 10,
        visibilityTimeout = Some(5),
        waitTimeSeconds = Some(20)
      ),
      extensionSettings = SqsMessageLifetimeExtensionSettings.default,
      consumerParallelism = 2
    ) { messages =>
      ZIO.debug(messages.map(_.body.getOrElse(""))) *> ZIO.sleep(14.seconds)
    }
```

The queue settings are:
![image](https://github.com/user-attachments/assets/dd364768-a0b6-48d2-bf80-086866208448)

Notice that I'm purposely taking 14 seconds when the visibility timeout is 5 seconds so that the automatic extension process is renewing the lease on the message and keeping it invisible from other queue consumers.

![image](https://github.com/user-attachments/assets/e122cf69-ff7e-4b96-a49c-426fceef8053)

Also did some checks to ensure that messages that are pulled from the queue won't reappear back on the queue due to the extension process that takes place in the background to minimize the change of duplicate processing.

---
### AWS SQS FIFO testing

Having a parallelism > message group id uniqueness will cap the parallelism to the unique message group ids

![image](https://github.com/user-attachments/assets/2d5660ec-bfff-4d33-b1d8-a13cfefb16d1)


```scala
  val producerLayer: RLayer[Sqs, Producer[String]] =
    ZLayer.scoped(
      Producer.make(
        queueUrl = "https://sqs.us-east-1.amazonaws.com/000/calq.fifo",
        serializer = Serializer.serializeString,
        settings = ProducerSettings(parallelism = 1)
      )
    )

  val producerExample =
    ZIO.serviceWithZIO[Producer[String]] { producer =>
      producer.produceBatch(
        (200 to 300).map(i =>
          ProducerEvent(
            data = s"Message $i",
            attributes = Map.empty,
            groupId = Some(
              if (i % 2 == 0) "even"
              else "odd"
            ),
            deduplicationId = None
          )
        )
      )
    }

  val consumerExample =
    SqsStream.consumeChunkAtLeastOnce(
      queueUrl = "https://sqs.us-east-1.amazonaws.com/000/calq.fifo",
      settings = SqsStreamSettings.default.copy(
        maxNumberOfMessages = Option(10),
        visibilityTimeout = Some(5),
        waitTimeSeconds = Some(20)
      ),
      extensionSettings = SqsMessageLifetimeExtensionSettings.default,
      consumerParallelism = 10
    ) { messages: Chunk[Message.ReadOnly] =>
      ZIO.debug(messages.map(_.body.getOrElse(""))) *> ZIO.sleep(14.seconds)
    }
```

Note how you only see at most 2 chunks being printed at a time. This is because of the message group id (even/odd -> 2 unique values). Note that even though consumer parallelism is set to 10. We are capped to 2 due to the amount of unique values. 
![stdout-fifo](https://github.com/user-attachments/assets/8c10ea1a-6515-4d2d-840a-e1e5ba46b40b)

Also note that the extension requests are working in the background because the queue settings are 5 seconds but the consumer takes 14 seconds to process them. Notice in the logs that there are no repeats printed
