### PR TITLE
Bump lib versions; Upgrade scala version to 2.13.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
     - name: Cache Dependencies
       uses: coursier/cache-action@v6
     - name: Setup NodeJs
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 16.x
         registry-url: https://registry.npmjs.org

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,9 @@
-val mainScala        = "2.13.17"
-val allScala         = Seq("3.3.6", "2.13.16")
-val zioVersion       = "2.1.22"
-val zioAwsVersion    = "7.37.4.1"
-val elasticMqVersion = "1.6.15"
+val mainScala         = "2.13.17"
+val allScala          = Seq("3.3.6", "2.13.16")
+val zioVersion        = "2.1.22"
+val zioAwsVersion     = "7.37.4.1"
+val elasticMqVersion  = "1.6.15"
+val semanticDbVersion = "4.14.1"
 
 enablePlugins(ZioSbtEcosystemPlugin, ZioSbtCiPlugin)
 
@@ -35,7 +36,7 @@ inThisBuild(
       )
     ),
     semanticdbEnabled := true,
-    semanticdbVersion := "4.14.1"
+    semanticdbVersion := semanticDbVersion
   )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 val mainScala         = "2.13.17"
-val allScala          = Seq("3.3.6", "2.13.16")
+val allScala          = Seq("3.3.6", "2.13.17")
 val zioVersion        = "2.1.22"
 val zioAwsVersion     = "7.37.4.1"
 val elasticMqVersion  = "1.6.15"

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 val mainScala        = "2.13.16"
 val allScala         = Seq("3.3.6", "2.13.16")
 val zioVersion       = "2.1.21"
-val zioAwsVersion    = "7.34.6.1"
+val zioAwsVersion    = "7.37.4.1"
 val elasticMqVersion = "1.6.15"
 
 enablePlugins(ZioSbtEcosystemPlugin, ZioSbtCiPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
-val mainScala        = "2.13.16"
+val mainScala        = "2.13.17"
 val allScala         = Seq("3.3.6", "2.13.16")
-val zioVersion       = "2.1.21"
+val zioVersion       = "2.1.22"
 val zioAwsVersion    = "7.37.4.1"
 val elasticMqVersion = "1.6.15"
 
@@ -34,7 +34,8 @@ inThisBuild(
         url("https://github.com/calvinlfer")
       )
     ),
-    semanticdbEnabled := true
+    semanticdbEnabled := true,
+    semanticdbVersion := "4.14.1"
   )
 )
 
@@ -63,7 +64,7 @@ lazy val sqs =
         "dev.zio"                %% "zio-streams"             % zioVersion,
         "dev.zio"                %% "zio-aws-sqs"             % zioAwsVersion,
         "dev.zio"                %% "zio-aws-netty"           % zioAwsVersion,
-        "org.scala-lang.modules" %% "scala-collection-compat" % "2.13.0",
+        "org.scala-lang.modules" %% "scala-collection-compat" % "2.14.0",
         "dev.zio"                %% "zio-test"                % zioVersion       % "test",
         "dev.zio"                %% "zio-test-sbt"            % zioVersion       % "test",
         "org.elasticmq"          %% "elasticmq-rest-sqs"      % elasticMqVersion % "test",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.5
+sbt.version=1.11.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,11 @@
-val zioSbtVersion = "0.4.0-alpha.34"
+val zioSbtVersion = "0.4.0-alpha.36"
 addSbtPlugin("dev.zio" % "zio-sbt-ecosystem" % zioSbtVersion)
 addSbtPlugin("dev.zio" % "zio-sbt-ci"        % zioSbtVersion)
 addSbtPlugin("dev.zio" % "zio-sbt-website"   % zioSbtVersion)
 
-addSbtPlugin("org.scalameta"    % "sbt-scalafmt"       % "2.5.5")
-addSbtPlugin("ch.epfl.scala"    % "sbt-scalafix"       % "0.14.3")
-addSbtPlugin("com.github.sbt"   % "sbt-github-actions" % "0.27.0")
+addSbtPlugin("org.scalameta"    % "sbt-scalafmt"       % "2.5.6")
+addSbtPlugin("ch.epfl.scala"    % "sbt-scalafix"       % "0.14.4")
+addSbtPlugin("com.github.sbt"   % "sbt-github-actions" % "0.28.0")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates"        % "0.6.4")
 
 resolvers ++= Resolver.sonatypeOssRepos("public")


### PR DESCRIPTION
While initial aim was to only bump zio-aws version, this lead to the scala version bump. 
Then I've started getting
```
Error downloading org.scalameta:semanticdb-scalac_2.13.17:4.9.9
```
I've updated all other explicit dependencies but that unfortunately didn't affect the error
So I had to set explicit version of semanticdb. I'm unsure if it's a correct approach though