### PR TITLE
CI: Add JDK 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
         java:
         - '17'
         - '21'
+        - '25'
     steps:
     - name: Install libuv
       run: sudo apt-get update && sudo apt-get install -y libuv1-dev


### PR DESCRIPTION
## Summary
- Add JDK 25 to the CI test matrix
- Test matrix is now: JDK 17, 21, 25